### PR TITLE
Plot any field in 3D or in 2D along/across front curtains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ cover/
 *.mo
 *.pot
 
+# Logs
+fronts/logs/
+
 # Django stuff:
 *.log
 local_settings.py

--- a/dev/mld/density_utils.py
+++ b/dev/mld/density_utils.py
@@ -211,15 +211,15 @@ def check_tiles_consistent(ds_a: xr.Dataset, ds_b: xr.Dataset,
 
     Raises
     ------
-    SystemExit
+    ValueError
         On any mismatch of tile_index / face_index / rect origins /
-        timestamp.
+        timestamp.  CLI callers should translate this to ``SystemExit``.
     """
     for key in ("tile_index", "face_index", "rect_i_start", "rect_j_start",
                 "timestamp"):
         va, vb = tile_scalar(ds_a, key), tile_scalar(ds_b, key)
         if str(va) != str(vb):
-            raise SystemExit(
+            raise ValueError(
                 f"Tile provenance mismatch: {label_a} has {key}={va!r} but "
                 f"{label_b} has {key}={vb!r}.  Both tiles must come from "
                 "the same tile window and timestamp."

--- a/dev/mld/density_utils.py
+++ b/dev/mld/density_utils.py
@@ -19,6 +19,7 @@ Conventions match the original script:
 
 # stdlib
 from __future__ import annotations
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -28,16 +29,65 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-# tile_mapping lives next to generate_tile_density.py in a sibling repo.
-# We mirror the sys.path trick used by generate_tile_density.py itself so
-# anyone importing this module gets the lookup available immediately.
-_TILE_MAPPING_DIR = Path(
-    "/home/xavier/Oceanography/python/llc4320-native-grid-preprocessing/"
-    "src/dbof/tiles"
-)
-if str(_TILE_MAPPING_DIR) not in sys.path:
-    sys.path.insert(0, str(_TILE_MAPPING_DIR))
-import tile_mapping  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# tile_mapping resolution
+# ---------------------------------------------------------------------------
+# ``tile_mapping`` lives in the sibling llc4320-native-grid-preprocessing repo.
+# Resolution order (no machine-specific path is hard-coded):
+#   1. the installed ``dbof`` package (``pip install -e`` of the preprocessing
+#      repo) -- the normal case, needs no configuration;
+#   2. the ``LLC4320_PREPROC_SRC`` environment variable, pointing at the
+#      preprocessing repo's ``src`` directory (or directly at ``.../dbof/tiles``);
+#   3. otherwise a clear ImportError explaining both options.
+def _import_tile_mapping():
+    """Import the preprocessing repo's ``tile_mapping`` module, robustly.
+
+    Returns
+    -------
+    module
+        The resolved ``tile_mapping`` module.
+
+    Raises
+    ------
+    ImportError
+        If the ``dbof`` package is not installed and ``LLC4320_PREPROC_SRC``
+        is unset or does not point at a directory containing ``tile_mapping``.
+    """
+    # 1. Installed package -- preferred; works with no configuration.
+    try:
+        import dbof.tiles.tile_mapping as tm
+        return tm
+    except ModuleNotFoundError:
+        pass
+
+    # 2. Environment-variable override (the "parsed input").  Accept either
+    #    the repo ``src`` dir or the ``dbof/tiles`` dir directly.
+    env_dir = os.environ.get("LLC4320_PREPROC_SRC")
+    if env_dir:
+        candidates = [
+            Path(env_dir),
+            Path(env_dir) / "dbof" / "tiles",
+            Path(env_dir) / "src" / "dbof" / "tiles",
+        ]
+        for cand in candidates:
+            if (cand / "tile_mapping.py").is_file():
+                if str(cand) not in sys.path:
+                    sys.path.insert(0, str(cand))
+                import tile_mapping as tm  # noqa: E402
+                return tm
+
+    raise ImportError(
+        "Could not import 'tile_mapping' from the llc4320-native-grid-"
+        "preprocessing repo.  Either `pip install -e` that repo so the "
+        "`dbof` package is importable, or set the LLC4320_PREPROC_SRC "
+        "environment variable to its `src` directory, e.g.\n"
+        "    export LLC4320_PREPROC_SRC=/path/to/"
+        "llc4320-native-grid-preprocessing/src"
+    )
+
+
+tile_mapping = _import_tile_mapping()
 
 
 # ---------------------------------------------------------------------------
@@ -71,41 +121,109 @@ def timestamp_to_stamp(timestamp: str) -> str:
 # Density-tile + global file loading
 # ---------------------------------------------------------------------------
 
-def load_density_tile(path: Path) -> xr.Dataset:
-    """Open the density-tile NetCDF and assert the required fields are present.
+def load_tile(path: Path, var_name: str | None = None) -> xr.Dataset:
+    """Open a property-tile NetCDF (any field) and validate its contents.
 
-    ``generate_tile_density.py`` writes some provenance as attrs and some as
-    scalar coords; we accept either location.
+    Tiles are written by ``llc4320-native-grid-preprocessing``'s
+    ``dbof.tiles.generate_tile`` and hold one 3-D data variable
+    (``sigma0``, ``Ri``, ``vorticity``, ...) plus ``XC``/``YC``/``Z``
+    coordinates and provenance fields (some as attrs, some as scalar
+    coords; we accept either location).
 
     Parameters
     ----------
     path : pathlib.Path
-        Path to the density-tile NetCDF produced by
-        ``generate_tile_density.py``.
+        Path to the tile NetCDF.
+    var_name : str or None, optional
+        Expected data-variable name.  When ``None`` the variable is
+        auto-detected (the single 3-D data variable in the file).
 
     Returns
     -------
     xarray.Dataset
-        Lazy dataset holding ``sigma0(k, j, i)``, plus the ``XC``, ``YC``,
-        ``Z`` coordinates and the ``tile_index``/``face_index``/
-        ``rect_i_start``/``rect_j_start``/``timestamp`` provenance fields.
+        Lazy dataset holding ``{var_name}(k, j, i)`` plus coordinates and
+        provenance.  The resolved variable name is recorded in
+        ``ds.attrs['tile_var_name']`` for convenience.
 
     Raises
     ------
     KeyError
-        If a required provenance field or the ``sigma0`` variable is absent.
+        If a required provenance field is absent, the requested variable is
+        missing, or (in auto-detect mode) the file does not contain exactly
+        one 3-D data variable.
     """
     ds = xr.open_dataset(path)
     for key in ("tile_index", "face_index", "rect_i_start", "rect_j_start",
                 "timestamp"):
         if key not in ds.attrs and key not in ds.coords:
             raise KeyError(
-                f"Density tile {path} missing required field '{key}' "
+                f"Tile {path} missing required field '{key}' "
                 "(checked attrs and coords)."
             )
-    if "sigma0" not in ds.data_vars:
-        raise KeyError(f"Density tile {path} has no 'sigma0' variable.")
+    if var_name is None:
+        candidates = [v for v in ds.data_vars if ds[v].ndim == 3]
+        if len(candidates) != 1:
+            raise KeyError(
+                f"Tile {path} should contain exactly one 3-D variable; "
+                f"found {candidates}.  Pass var_name= explicitly."
+            )
+        var_name = candidates[0]
+    elif var_name not in ds.data_vars:
+        raise KeyError(
+            f"Tile {path} has no '{var_name}' variable "
+            f"(data_vars={list(ds.data_vars)})."
+        )
+    ds.attrs["tile_var_name"] = var_name
     return ds
+
+
+def load_density_tile(path: Path) -> xr.Dataset:
+    """Backward-compatible wrapper: :func:`load_tile` pinned to ``sigma0``.
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        Path to the density-tile NetCDF.
+
+    Returns
+    -------
+    xarray.Dataset
+        See :func:`load_tile`.
+    """
+    return load_tile(path, var_name="sigma0")
+
+
+def check_tiles_consistent(ds_a: xr.Dataset, ds_b: xr.Dataset,
+                           label_a: str = "tile A",
+                           label_b: str = "tile B") -> None:
+    """Hard-error unless two tiles share geometry and timestamp provenance.
+
+    Used by ``fronts_viz_3d`` to confirm that a color-field tile (e.g. Ri)
+    was generated for the same tile window and snapshot as the density tile
+    that drives the scene geometry.
+
+    Parameters
+    ----------
+    ds_a, ds_b : xarray.Dataset
+        Tile datasets from :func:`load_tile`.
+    label_a, label_b : str, optional
+        Names used in the error message.
+
+    Raises
+    ------
+    SystemExit
+        On any mismatch of tile_index / face_index / rect origins /
+        timestamp.
+    """
+    for key in ("tile_index", "face_index", "rect_i_start", "rect_j_start",
+                "timestamp"):
+        va, vb = tile_scalar(ds_a, key), tile_scalar(ds_b, key)
+        if str(va) != str(vb):
+            raise SystemExit(
+                f"Tile provenance mismatch: {label_a} has {key}={va!r} but "
+                f"{label_b} has {key}={vb!r}.  Both tiles must come from "
+                "the same tile window and timestamp."
+            )
 
 
 def tile_scalar(ds: xr.Dataset, key: str):

--- a/docs/viz/INDEX.md
+++ b/docs/viz/INDEX.md
@@ -7,6 +7,7 @@ These scripts cover four different visual stories and use four different renderi
 | Script | What it shows | Backend | Output |
 |---|---|---|---|
 | [fronts_viz_3d.py](fronts_viz_3d.md) | One labelled front extruded through a 3-D sigma0 volume down to a few levels below the MLD. | PyVista (VTK) | PNG + interactive HTML + 2-D matplotlib inset |
+| [fronts_viz_curtain.py](fronts_curtain.md) | 2-D vertical "curtain" cross-sections of one labelled front: main-axis, along-front offsets, and a cross-front transect; color = a field (default Ri), contours = isopycnals. | matplotlib | PNG (×3) + plan-view inset |
 | [front_property_viewer.py](front_property_viewer.md) | Four linked 2-D panels in a regional bbox: gradb2 + binary fronts + three derived fields you choose. | PyQt6 + pyqtgraph | Interactive GUI window |
 | [global_field_viewer.py](global_field_viewer.md) | The full global LLC4320 field at one timestep with one or two front masks overlaid. | PyQt6 + pyqtgraph | Interactive GUI window |
 | [front_viz_groups_bokeh.py](front_viz_groups_bokeh.md) | Labelled-front background with per-front properties exposed as hover tooltips. | Bokeh | Standalone HTML |
@@ -20,7 +21,9 @@ The 3-D pipeline introduced a couple of re-usable modules; the rest of the viz s
 |---|---|---|
 | [fronts/viz/pv_helpers.py](../../fronts/viz/pv_helpers.py) | fronts_viz_3d | Generic PyVista wrappers: `ensure_display` (Xvfb), `new_plotter`, `scientific_theme`, `add_scalar_field`, `save_with_rst`. |
 | [fronts/viz/fronts_3d.py](../../fronts/viz/fronts_3d.py) | fronts_viz_3d | Front-specific PyVista builders: `front_bbox_and_crop`, `truncate_depth`, `build_pyvista_grid`, `decompose_front_branches`, `build_front_curtain`, `pick_isopycnals_across_front`, `render_3d`. |
-| [fronts/viz/insets.py](../../fronts/viz/insets.py) | fronts_viz_3d | Matplotlib 2-D companion inset (`plot_bbox_inset`). Kept separate from `viz_utils.py` which is pyqtgraph-based. |
+| [fronts/viz/insets.py](../../fronts/viz/insets.py) | fronts_viz_3d, fronts_viz_curtain | Matplotlib 2-D companion inset (`plot_bbox_inset`). Kept separate from `viz_utils.py` which is pyqtgraph-based. |
+| [fronts/viz/curtains.py](../../fronts/viz/curtains.py) | fronts_viz_curtain | Matplotlib curtain builders: `extract_main_axis` (skeleton diameter), `path_metrics`, `offset_paths`, `perpendicular_path`, `offset_quality_flags`, `sample_curtain`, `pick_extremum_index`, and the figure assemblers. Imports `decompose_front_branches` lazily so it needs no PyVista. |
+| [fronts/viz/field_styles.py](../../fronts/viz/field_styles.py) | fronts_viz_3d, fronts_viz_curtain | Per-variable display registry (transform / clip / cmap / title / center) for the color field; `apply_transform`, `default_clim`. |
 | [fronts/viz/viz_utils.py](../../fronts/viz/viz_utils.py) | front_property_viewer, global_field_viewer | Pyqtgraph helpers: `make_colormap`, `compute_levels`, `make_fronts_rgba`, `make_nan_rgba`. |
 | [fronts/llc/analysis.py](../../fronts/llc/analysis.py) | fronts_viz_3d (and `dev/mld/plot_top_N_density_profiles.py` after the v1 refactor) | Stratification diagnostics: scalar `mixed_layer_depth` and vectorised `mixed_layer_depth_field`. The threshold is a parameter, so the same helper covers the 0.03 ("mixed layer") and 0.125 ("isopycnal MLD") conventions. |
 

--- a/docs/viz/fronts_curtain.md
+++ b/docs/viz/fronts_curtain.md
@@ -6,12 +6,12 @@ It reuses the 3-D script's tile-loading, frame-remapping, and front-picking pipe
 
 ## What it produces
 
-Four PNGs per run, all sharing the `--output-prefix`. The filenames embed the field name (`{field}` = the tile variable, e.g. `Ri`) and, for the offsets figure, the offset count (`{N}` = `--n-offsets`):
+Four PNGs per run, all sharing the `--output-prefix`. The filenames embed the field name (`{field}` = the tile variable, e.g. `Ri`), the picked front's location (`{loc}` = `lat{LAT}_lon{LON}`, e.g. `lat36.38_lon-124.20`, so different fronts don't overwrite each other), and — for the offsets figure — the offset count (`{N}` = `--n-offsets`):
 
-- **`{prefix}_{field}_mainaxis.png`** — the main-axis curtain (single panel).
-- **`{prefix}_{field}_offsets_n{N}.png`** — along-front curtains: two summary (dilation) rows on top + the `N` individual offset rows (two columns × `N+2` rows).
-- **`{prefix}_{field}_perp.png`** — the cross-front (perpendicular) curtain (single panel).
-- **`{prefix}_{field}_inset.png`** — a plan-view map of the bbox: the **color field** near-surface slice (same colormap/colorbar as the curtains) with the main axis, the offset envelope, and the marked perpendicular point overlaid (opt out with `--no-inset`).
+- **`{prefix}_{field}_{loc}_mainaxis.png`** — the main-axis curtain (single panel).
+- **`{prefix}_{field}_{loc}_offsets_n{N}.png`** — along-front curtains: two summary (dilation) rows on top + the `N` individual offset rows (two columns × `N+2` rows).
+- **`{prefix}_{field}_{loc}_perp.png`** — the cross-front (perpendicular) curtain (single panel).
+- **`{prefix}_{field}_{loc}_inset.png`** — a plan-view map of the bbox: the **color field** near-surface slice (same colormap/colorbar as the curtains) with the main axis, the offset envelope, and the marked perpendicular point overlaid (opt out with `--no-inset`).
 
 All figures are static matplotlib (Agg backend, dpi 150), matching the repo's existing 2-D companion in [fronts/viz/insets.py](../../fronts/viz/insets.py).
 
@@ -135,7 +135,7 @@ python -m fronts.scripts.fronts_viz_curtain \
 | `--n-isopycnals` | int | `8` | Number of auto-picked isopycnal levels. |
 | `--clim` | LO HI | style clim, else 2/98 pct | Color limits for the (transformed) color field. |
 | `--cmap` | str | field-style cmap | Colormap for the color field. |
-| `--output-prefix` | path | required | Prefix; appends `_{field}_mainaxis.png` / `_{field}_offsets_n{N}.png` / `_{field}_perp.png` / `_{field}_inset.png` (`{field}` = tile variable name, `{N}` = `--n-offsets`). |
+| `--output-prefix` | path | required | Prefix; appends `_{field}_{loc}_mainaxis.png` / `_..._offsets_n{N}.png` / `_..._perp.png` / `_..._inset.png` (`{field}` = tile variable, `{loc}` = `lat{LAT}_lon{LON}`, `{N}` = `--n-offsets`). The lat/lon prevents different fronts overwriting each other. |
 | `--no-inset` | flag | off | Skip the plan-view map inset. |
 
 ## Module map

--- a/docs/viz/fronts_curtain.md
+++ b/docs/viz/fronts_curtain.md
@@ -1,0 +1,164 @@
+# `fronts_viz_curtain` — 2-D "curtain" cross-sections of a single labelled front
+
+[fronts/scripts/fronts_viz_curtain.py](../../fronts/scripts/fronts_viz_curtain.py) is the 2-D companion to [`fronts_viz_3d`](fronts_viz_3d.md). Instead of a 3-D PyVista scene it produces flat **curtain** plots — vertical cross-sections sampled along a path through the tile, with **distance along the path** on the x-axis, **depth** on the y-axis, a configurable field (default the Richardson number `Ri`) as **color**, and **isopycnals** (σ₀ surfaces) overlaid as contour lines.
+
+It reuses the 3-D script's tile-loading, frame-remapping, and front-picking pipeline verbatim, so the inputs and locators are identical.
+
+## What it produces
+
+Four PNGs per run, all sharing the `--output-prefix`:
+
+- **`{prefix}_mainaxis.png`** — the main-axis curtain (single panel).
+- **`{prefix}_offsets.png`** — along-front curtains with offsets (two columns × `N+1` rows).
+- **`{prefix}_perp.png`** — the cross-front (perpendicular) curtain (single panel).
+- **`{prefix}_inset.png`** — a plan-view map of the bbox showing the main axis, the offset envelope, and the marked perpendicular point (opt out with `--no-inset`).
+
+All figures are static matplotlib (Agg backend, dpi 150), matching the repo's existing 2-D companion in [fronts/viz/insets.py](../../fronts/viz/insets.py).
+
+## The three figures
+
+### 1. Main-axis curtain
+
+Plots only the front's **main axis** — the longest end-to-end path through the thinned skeleton, with side branches dropped (see [Main-axis extraction](#main-axis-extraction)). Every real front pixel along that path is one curtain column; nothing is resampled onto evenly-spaced points. x = distance along the front (pixels, with a km twin axis on top), y = depth, color = the selected field, σ₀ isopycnals overlaid, the mixed-layer depth drawn as a dashed white line, and the chosen perpendicular point marked with a green vertical line.
+
+### 2. Along-front curtains with offsets
+
+Two columns — one per side of the front. **Row 0 of both columns is the main-axis curtain itself** (offset 0). Rows 1..N show curtains sampled along paths offset 1..N pixels away from the axis, on the `+normal` side (left column) and `-normal` side (right column). All panels share one color scale for comparability.
+
+Where the offset geometry **self-overlaps** — the concave side of a bend, or residual skeleton noise — the affected columns are shaded magenta and the count is noted in the panel title (see [Offsets and self-overlap](#offsets-and-self-overlap)). Off-window/NaN cells render in neutral gray, so the two failure modes are visually distinct.
+
+### 3. Cross-front (perpendicular) curtain
+
+A perpendicular transect is cut at a chosen point along the main axis. By default that point is the **field extremum over the full curtain depth** (e.g. the column whose deepest-searched `Ri` is lowest — most shear-unstable); override the search direction with `--extremum max` or pin a specific column with `--perp-point`. The transect spans `2·--perp-half-width + 1` pixels; the curtain's x-axis is **signed cross-front distance** with 0 at the front axis (negative on side B, positive on side A).
+
+## Inputs
+
+Same as `fronts_viz_3d`, with one difference: the field tile is **required** here (it supplies both the curtain color and the perpendicular-point extremum).
+
+1. **3-D density tile** — NetCDF from `generate_tile.py`. `sigma0(k, j, i)` on face-local axes, plus `XC`/`YC`/`Z` and `rect_i_start`/`rect_j_start`/`face_index` provenance. Drives the isopycnal contours.
+2. **Field tile** (`--field-tile`, **required**) — a second NetCDF (same tile window + timestamp) holding the color field, e.g. a `Ri` tile from `--property richardson`. Auto-detects the single 3-D variable unless `--field-name` is given.
+3. **Labelled-fronts mask** — global `.npy`/`.nc` on the rect grid (integer labels, `0 = no front`).
+4. **Locator** — `(--i, --j)` rect indices or `(--lat, --lon)` degrees (snapped to the nearest labelled pixel).
+
+## Frame handling
+
+Identical to the 3-D script: `build_tile_lookup` gives the per-pixel `(j_face, i_face)` for every rect-tile-local pixel; σ₀, the field, `XC`, `YC` are fancy-indexed onto the rect frame; everything downstream operates in the one coordinate system that matches `--i / --j`.
+
+## Algorithm flow
+
+1. **Load** — `load_density_tile` + `load_tile` (field) + `load_labels_tile`; `check_tiles_consistent` enforces matching provenance.
+2. **Remap** — `remap_to_rect` (reused from `fronts_viz_3d`) for σ₀, the field, `XC`, `YC`.
+3. **Pick label** — `pick_front_label` (reused) via `(--i,--j)` or snapped `(--lat,--lon)`.
+4. **Crop** — `front_bbox_and_crop` → `(j_slice, i_slice)` over the bbox + `--margin`.
+5. **MLD + depth clip** — `mixed_layer_depth_field` then `truncate_depth` keep levels `0 .. max(k_mld) + --n-below`; this sets the curtain's depth extent.
+6. **Color transform** — `apply_transform` from [field_styles.py](../../fronts/viz/field_styles.py) maps raw field → display values (for `Ri`: `log10(clip(Ri, 1e-2, 1e4))`, `Ri ≤ 0 → NaN`).
+7. **Main axis** — `curtains.extract_main_axis` (skeleton diameter; see below).
+8. **Path metrics** — `curtains.path_metrics` returns per-pixel pixel-distance, great-circle km distance, and unit tangents/normals. `--smooth-normals` smooths *only* the direction field.
+9. **Isopycnal levels** — `pick_isopycnal_levels` brackets the 2/98 percentile of the whole clipped volume (the curtain spans full depth), or uses `--isopycnals`.
+10. **Perpendicular point** — `--perp-point`, else `curtains.pick_extremum_index` over the full-depth axis curtain.
+11. **Render** — `curtains.figure_main_axis`, `figure_offsets`, `figure_perpendicular`, and the script's `plot_map_inset`.
+
+## Main-axis extraction
+
+`extract_main_axis` builds on the 3-D module's `decompose_front_branches` (a custom 8-neighbour DFS that splits the thinned skeleton into branch polylines between junctions and endpoints). Those branches form a graph whose nodes are branch end pixels and whose edges are weighted by branch arc length (4-connected steps = 1, diagonal = √2). The **main axis is the graph diameter** — the longest end-to-end path — found by a double Dijkstra sweep (farthest node from an arbitrary start, then farthest from that node). Only the branches on that path are concatenated, so **side branches are dropped by construction**. Closed loops still yield a finite, well-defined diameter. Single-pixel and degenerate masks fall back to the longest available branch.
+
+> The `decompose_front_branches` import is lazy, so importing `fronts.viz.curtains` does **not** require PyVista — the 2-D viewer runs without the 3-D rendering stack.
+
+## Path metrics, smoothing, and km distance
+
+`path_metrics` returns arrays aligned 1:1 with the main-axis pixels — it never resamples or moves columns:
+
+- **`dist_px`** — cumulative Euclidean pixel distance between consecutive real pixels (so diagonal hops add √2).
+- **`dist_km`** — cumulative haversine great-circle distance from `XC`/`YC` at the real pixels. This is just a relabelling of the same columns; the km axis on the figures is interpolated onto the pixel ticks.
+- **`tangents` / `normals`** — unit direction vectors used to throw offsets and the perpendicular.
+
+**Smoothing (`--smooth-normals`, off by default)** applies a moving average of width `--smooth-window` (odd, default 5) to the tangent direction before deriving normals. It affects **only the direction field** — never the main-axis column positions or the distances. A raw thinned skeleton zig-zags between 4- and 8-connected steps, so per-pixel normals can swing ~45–90° between neighbours; that throws adjacent offset points in inconsistent directions and makes them collide immediately. Smoothing averages those kinks out so offsets stay roughly parallel. Render the same front both ways to compare.
+
+## Offsets and self-overlap
+
+`offset_paths` shifts the main axis ±k pixels along the per-pixel normal for k = 1..N, giving two mirror-image families (side A = `+normal`, side B = `−normal`). Each offset path is sampled exactly like the main axis.
+
+`offset_quality_flags` flags a column when its offset point lands within `< 1 px` of any *non-adjacent* column's offset point — the signature of the concave side of a bend folding back, or of residual skeleton noise when smoothing is off. Flagged columns are shaded so the curtain still renders but the unreliable region is obvious. There are two distinct, separately-shaded failure modes: **magenta** = offset self-overlap; **neutral gray** = off-window/NaN sample.
+
+Two causes of overlap, two responses: pixel-scale jaggedness is best removed by `--smooth-normals` (it's an artifact); genuine tight curvature is real geometry, so it is marked rather than hidden. A more-correct centre-of-curvature offset (move outward from the local centre of curvature instead of straight along the normal) would handle the second case but is fragile to the first and is left as a follow-up.
+
+## Curtain sampling
+
+`sample_curtain(field3d, path)` samples a `(K, J, I)` field along a `(j, i)` path at every depth via `scipy.ndimage.map_coordinates(order=1, mode="constant", cval=nan)`, returning a `(K, L)` array. This mirrors the inner loop of `fronts_3d.build_front_curtain` but returns a plain array for matplotlib. Paths leaving the cropped window come back as NaN, which the renderer shades neutral gray.
+
+## CLI
+
+```text
+python -m fronts.scripts.fronts_viz_curtain \
+    --density-tile density_tile330_20121109T12.nc \
+    --field-tile   Ri_tile330_20121109T12.nc \
+    --labels       labeled_fronts_global_20121109T12_00_00_V4.npy \
+    --i 13142 --j 9956 \
+    --n-offsets 3 --perp-half-width 30 \
+    --output-prefix /tmp/calcurrent_curtain
+```
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--density-tile` | path | required | NetCDF density tile (σ₀); drives isopycnals. |
+| `--field-tile` | path | **required** | Field tile (same window+timestamp) coloring the curtains, e.g. a `Ri` tile. |
+| `--field-name` | str | auto | Variable inside `--field-tile` (default: the single 3-D variable). |
+| `--field-transform` | `log10`/`symlog`/`linear` | style | Override the field's registered transform. |
+| `--field-clip` | LO HI | style | Override the field's raw-value clip range. |
+| `--labels` | path | required | Global integer-labels mask (`.npy` or `.nc`). |
+| `--i / --j` | int | — | Rect-grid pixel coordinates (locator option A). |
+| `--lat / --lon` | float | — | Degrees (locator option B); snapped to the nearest labelled pixel. |
+| `--margin` | int | `50` | Pixel margin around the front bbox. |
+| `--n-below` | int | `3` | LLC levels below the deepest MLD to include (sets depth extent). |
+| `--n-offsets` | int | `3` | Number of offset rows per side. |
+| `--perp-half-width` | int | `30` | Half-width (px) of the perpendicular transect (length `2N+1`). |
+| `--perp-point` | int | extremum | Main-axis column index for the perpendicular transect. |
+| `--extremum` | `min`/`max` | `min` | Default perpendicular point = field min (e.g. lowest `Ri`) or max. |
+| `--smooth-normals` | flag | off | Smooth the tangent/normal direction field before offsets/perpendicular. Never moves the main-axis columns. |
+| `--smooth-window` | int | `5` | Odd pixel window for `--smooth-normals`. |
+| `--isopycnals` | floats | auto | Explicit σ₀ contour levels. |
+| `--n-isopycnals` | int | `8` | Number of auto-picked isopycnal levels. |
+| `--clim` | LO HI | style clim, else 2/98 pct | Color limits for the (transformed) color field. |
+| `--cmap` | str | field-style cmap | Colormap for the color field. |
+| `--output-prefix` | path | required | Prefix; appends `_mainaxis.png` / `_offsets.png` / `_perp.png` / `_inset.png`. |
+| `--no-inset` | flag | off | Skip the plan-view map inset. |
+
+## Module map
+
+| File | Role |
+|---|---|
+| [fronts/scripts/fronts_viz_curtain.py](../../fronts/scripts/fronts_viz_curtain.py) | CLI orchestrator; reuses the `fronts_viz_3d` ingest pipeline + the map-view inset. |
+| [fronts/viz/curtains.py](../../fronts/viz/curtains.py) | Reusable builders: `extract_main_axis`, `path_metrics`, `offset_paths`, `perpendicular_path`, `offset_quality_flags`, `sample_curtain`, `pick_extremum_index`, and the matplotlib panel/figure renderers. |
+| [fronts/viz/fronts_3d.py](../../fronts/viz/fronts_3d.py) | Reused for `decompose_front_branches` (lazy import), `front_bbox_and_crop`, `truncate_depth`. |
+| [fronts/viz/field_styles.py](../../fronts/viz/field_styles.py) | Per-variable transform / clip / cmap / title for the color field. |
+| [fronts/llc/analysis.py](../../fronts/llc/analysis.py) | `mixed_layer_depth_field` for the depth clip + MLD overlay. |
+| [dev/mld/density_utils.py](../../dev/mld/density_utils.py) | `load_density_tile`, `load_tile`, `load_labels_tile`, `build_tile_lookup`, `tile_scalar`, `attach_lonlat_twins`. |
+
+### Public helpers in `fronts/viz/curtains.py`
+
+| Function | What it does |
+|---|---|
+| `extract_main_axis(front_mask)` | Longest end-to-end path through the skeleton (diameter); side branches dropped. |
+| `path_metrics(path, XC, YC, smooth=, smooth_window=)` | Per-pixel `dist_px` / `dist_km` / unit tangents / normals. Smoothing affects directions only. |
+| `offset_paths(path, normals, n)` | Two mirror families of offset polylines (sides A/B). |
+| `perpendicular_path(path, normals, idx, half_width)` | Cross-front transect centered on `path[idx]`. |
+| `offset_quality_flags(offset_path)` | Boolean mask of self-overlapping columns (< 1 px collision). |
+| `sample_curtain(field3d, path)` | `(K, L)` sample of a field along a path at every depth; off-window → NaN. |
+| `pick_extremum_index(curtain_field, mode)` | Column of the full-depth min/max of the field. |
+| `plot_curtain_panel(ax, ...)` | One curtain panel: color mesh + isopycnal contours + km twin axis + MLD + overlap shading. |
+| `figure_main_axis / figure_offsets / figure_perpendicular(...)` | The three deliverable figures. |
+
+## Testing
+
+[fronts/tests/test_curtains.py](../../fronts/tests/test_curtains.py) covers the geometry and sampling with synthetic skeletons: straight / branched / curved / single-pixel main-axis extraction, normals and km distances, smoothing-keeps-columns invariance, offset mirror symmetry, self-overlap detection on tight curves, NaN handling off-window, perpendicular geometry, and extremum picking.
+
+```bash
+pytest fronts/tests/test_curtains.py
+```
+
+## Known follow-ups
+
+- **Centre-of-curvature offsets** — offset outward from the local centre of curvature instead of straight along the normal, for a more correct concave-side spacing. Deferred (fragile to pixel-scale noise; needs smoothing first).
+- **km twin axis on the perpendicular figure** — currently the perpendicular x-axis is signed pixels only; a signed-km twin could be added.
+- **Adaptive `--perp-half-width`** from the front's local cross-stream density scale.
+- **Shared interactive HTML** (plotly) export, if hover/zoom is wanted — not currently a repo pattern.

--- a/docs/viz/fronts_curtain.md
+++ b/docs/viz/fronts_curtain.md
@@ -25,11 +25,11 @@ Plots only the front's **main axis** — the longest end-to-end path through the
 
 Two columns — one per side of the front. **Row 0 of both columns is the main-axis curtain itself** (offset 0). Rows 1..N show curtains sampled along paths offset 1..N pixels away from the axis, on the `+normal` side (left column) and `-normal` side (right column). All panels share one color scale for comparability.
 
-Where the offset geometry **self-overlaps** — the concave side of a bend, or residual skeleton noise — the affected columns are shaded magenta and the count is noted in the panel title (see [Offsets and self-overlap](#offsets-and-self-overlap)). Off-window/NaN cells render in neutral gray, so the two failure modes are visually distinct.
+By default each offset line is **trimmed** of self-intersection loops so it contains no crossings — the looped columns on the concave side of a bend are excised ("sewn shut") and render as neutral-gray gaps in the curtain (and as a continuous, crossing-free line on the inset). Pass `--no-trim-offsets` to keep the loops instead and shade them magenta. Off-window/NaN cells always render gray. See [Offsets, trimming, and self-overlap](#offsets-trimming-and-self-overlap).
 
 ### 3. Cross-front (perpendicular) curtain
 
-A perpendicular transect is cut at a chosen point along the main axis. By default that point is the **field extremum over the full curtain depth** (e.g. the column whose deepest-searched `Ri` is lowest — most shear-unstable); override the search direction with `--extremum max` or pin a specific column with `--perp-point`. The transect spans `2·--perp-half-width + 1` pixels; the curtain's x-axis is **signed cross-front distance** with 0 at the front axis (negative on side B, positive on side A).
+A perpendicular transect is cut at a chosen point along the main axis. By default that point is the **field extremum over the full curtain depth** (e.g. the column whose deepest-searched `Ri` is lowest — most shear-unstable), **restricted to columns whose transect crosses the front at most `--perp-max-crossings` times (default 1)** so the transect lands on a clean stretch rather than the front's squiggly self-overlapping parts. Override with `--extremum max`, lift the crossing filter with `--perp-allow-crossings`, or pin a specific column with `--perp-point` (use `--list-perp-candidates` to print each column's `(i, j)`, along-path km, and crossing count). The transect spans `2·--perp-half-width + 1` pixels — which is exactly the length of the green line drawn on the inset — and the curtain's x-axis is **signed cross-front distance** with 0 at the front axis (negative on side B, positive on side A).
 
 ## Inputs
 
@@ -55,7 +55,7 @@ Identical to the 3-D script: `build_tile_lookup` gives the per-pixel `(j_face, i
 7. **Main axis** — `curtains.extract_main_axis` (skeleton diameter; see below).
 8. **Path metrics** — `curtains.path_metrics` returns per-pixel pixel-distance, great-circle km distance, and unit tangents/normals. `--smooth-normals` smooths *only* the direction field.
 9. **Isopycnal levels** — `pick_isopycnal_levels` brackets the 2/98 percentile of the whole clipped volume (the curtain spans full depth), or uses `--isopycnals`.
-10. **Perpendicular point** — `--perp-point`, else `curtains.pick_extremum_index` over the full-depth axis curtain.
+10. **Perpendicular point** — `--perp-point`, else `curtains.pick_extremum_index` over the full-depth axis curtain, with columns whose transect re-crosses the front (`curtains.transect_front_crossings > --perp-max-crossings`) excluded unless `--perp-allow-crossings`.
 11. **Render** — `curtains.figure_main_axis`, `figure_offsets`, `figure_perpendicular`, and the script's `plot_map_inset`.
 
 ## Main-axis extraction
@@ -74,13 +74,18 @@ Identical to the 3-D script: `build_tile_lookup` gives the per-pixel `(j_face, i
 
 **Smoothing (`--smooth-normals`, off by default)** applies a moving average of width `--smooth-window` (odd, default 5) to the tangent direction before deriving normals. It affects **only the direction field** — never the main-axis column positions or the distances. A raw thinned skeleton zig-zags between 4- and 8-connected steps, so per-pixel normals can swing ~45–90° between neighbours; that throws adjacent offset points in inconsistent directions and makes them collide immediately. Smoothing averages those kinks out so offsets stay roughly parallel. Render the same front both ways to compare.
 
-## Offsets and self-overlap
+## Offsets, trimming, and self-overlap
 
 `offset_paths` shifts the main axis ±k pixels along the per-pixel normal for k = 1..N, giving two mirror-image families (side A = `+normal`, side B = `−normal`). Each offset path is sampled exactly like the main axis.
 
-`offset_quality_flags` flags a column when its offset point lands within `< 1 px` of any *non-adjacent* column's offset point — the signature of the concave side of a bend folding back, or of residual skeleton noise when smoothing is off. Flagged columns are shaded so the curtain still renders but the unreliable region is obvious. There are two distinct, separately-shaded failure modes: **magenta** = offset self-overlap; **neutral gray** = off-window/NaN sample.
+On the concave side of a bend an offset folds back and crosses itself. Two handling modes:
 
-Two causes of overlap, two responses: pixel-scale jaggedness is best removed by `--smooth-normals` (it's an artifact); genuine tight curvature is real geometry, so it is marked rather than hidden. A more-correct centre-of-curvature offset (move outward from the local centre of curvature instead of straight along the normal) would handle the second case but is fragile to the first and is left as a follow-up.
+- **Trim (default).** `trim_offset_loops` finds each pair of crossing segments and excises the looped vertices between them, leaving a shorter but crossing-free polyline — the "sew the line shut" behaviour. The dropped columns are NaN'd in the curtain (gray gaps) and skipped on the inset line, so neither the curtain nor the map ever shows a self-crossing offset. Trimming runs whether or not `--smooth-normals` is set, but smoothing first gives cleaner results because it removes the pixel-scale kinks that create spurious tiny loops.
+- **Shade (`--no-trim-offsets`).** Keep the loops and instead flag them: `offset_quality_flags` marks a column when its offset point lands within `< 1 px` of any non-adjacent column's offset point, and those columns are shaded magenta. The curtain still renders; the unreliable region is just made obvious.
+
+Either way the two failure modes stay visually distinct: **gray** = trimmed loop or off-window/NaN sample; **magenta** (shade mode only) = kept self-overlap.
+
+Two causes of overlap, two complementary tools: pixel-scale jaggedness is an artifact best removed by `--smooth-normals`; genuine tight curvature is real geometry, removed cleanly by trimming. A more-correct centre-of-curvature offset (move outward from the local centre of curvature instead of straight along the normal) would *preserve* rather than drop the concave-side material, but it is fragile to pixel noise and is left as a follow-up.
 
 ## Curtain sampling
 
@@ -111,11 +116,15 @@ python -m fronts.scripts.fronts_viz_curtain \
 | `--margin` | int | `50` | Pixel margin around the front bbox. |
 | `--n-below` | int | `3` | LLC levels below the deepest MLD to include (sets depth extent). |
 | `--n-offsets` | int | `3` | Number of offset rows per side. |
-| `--perp-half-width` | int | `30` | Half-width (px) of the perpendicular transect (length `2N+1`). |
+| `--perp-half-width` | int | `30` | Half-width (px) of the perpendicular transect (length `2N+1`); also the length of the green line on the inset. |
 | `--perp-point` | int | extremum | Main-axis column index for the perpendicular transect. |
 | `--extremum` | `min`/`max` | `min` | Default perpendicular point = field min (e.g. lowest `Ri`) or max. |
+| `--perp-max-crossings` | int | `1` | Auto-pick only considers columns whose transect crosses the front ≤ this many times (keeps it off the squiggly hook). |
+| `--perp-allow-crossings` | flag | off | Disable the crossing filter; auto-pick the extremum anywhere. |
+| `--list-perp-candidates` | flag | off | Log each column's `(i, j)`, along-path km, and crossing count, then continue. Helps choose `--perp-point`. |
 | `--smooth-normals` | flag | off | Smooth the tangent/normal direction field before offsets/perpendicular. Never moves the main-axis columns. |
 | `--smooth-window` | int | `5` | Odd pixel window for `--smooth-normals`. |
+| `--no-trim-offsets` | flag | off (trim on) | Keep offset self-intersection loops (shaded magenta) instead of trimming them to crossing-free lines. |
 | `--isopycnals` | floats | auto | Explicit σ₀ contour levels. |
 | `--n-isopycnals` | int | `8` | Number of auto-picked isopycnal levels. |
 | `--clim` | LO HI | style clim, else 2/98 pct | Color limits for the (transformed) color field. |
@@ -142,7 +151,9 @@ python -m fronts.scripts.fronts_viz_curtain \
 | `path_metrics(path, XC, YC, smooth=, smooth_window=)` | Per-pixel `dist_px` / `dist_km` / unit tangents / normals. Smoothing affects directions only. |
 | `offset_paths(path, normals, n)` | Two mirror families of offset polylines (sides A/B). |
 | `perpendicular_path(path, normals, idx, half_width)` | Cross-front transect centered on `path[idx]`. |
-| `offset_quality_flags(offset_path)` | Boolean mask of self-overlapping columns (< 1 px collision). |
+| `offset_quality_flags(offset_path)` | Boolean mask of self-overlapping columns (< 1 px collision); used in `--no-trim-offsets` mode. |
+| `trim_offset_loops(offset_path)` | Keep-mask that excises self-intersection loops so the offset line has no crossings ("sew shut"). |
+| `transect_front_crossings(axis, normals, mask, half_width)` | Per-column count of how many times the perpendicular transect hits the front; drives the perpendicular auto-pick filter. |
 | `sample_curtain(field3d, path)` | `(K, L)` sample of a field along a path at every depth; off-window → NaN. |
 | `pick_extremum_index(curtain_field, mode)` | Column of the full-depth min/max of the field. |
 | `plot_curtain_panel(ax, ...)` | One curtain panel: color mesh + isopycnal contours + km twin axis + MLD + overlap shading. |
@@ -158,7 +169,7 @@ pytest fronts/tests/test_curtains.py
 
 ## Known follow-ups
 
-- **Centre-of-curvature offsets** — offset outward from the local centre of curvature instead of straight along the normal, for a more correct concave-side spacing. Deferred (fragile to pixel-scale noise; needs smoothing first).
+- **Centre-of-curvature offsets** — offset outward from the local centre of curvature instead of straight along the normal, for a more correct concave-side spacing that *preserves* rather than trims the inner material. Deferred (fragile to pixel-scale noise; needs smoothing first).
 - **km twin axis on the perpendicular figure** — currently the perpendicular x-axis is signed pixels only; a signed-km twin could be added.
 - **Adaptive `--perp-half-width`** from the front's local cross-stream density scale.
 - **Shared interactive HTML** (plotly) export, if hover/zoom is wanted — not currently a repo pattern.

--- a/docs/viz/fronts_curtain.md
+++ b/docs/viz/fronts_curtain.md
@@ -6,12 +6,12 @@ It reuses the 3-D script's tile-loading, frame-remapping, and front-picking pipe
 
 ## What it produces
 
-Four PNGs per run, all sharing the `--output-prefix`:
+Four PNGs per run, all sharing the `--output-prefix`. The filenames embed the field name (`{field}` = the tile variable, e.g. `Ri`) and, for the offsets figure, the offset count (`{N}` = `--n-offsets`):
 
-- **`{prefix}_mainaxis.png`** — the main-axis curtain (single panel).
-- **`{prefix}_offsets.png`** — along-front curtains with offsets (two columns × `N+1` rows).
-- **`{prefix}_perp.png`** — the cross-front (perpendicular) curtain (single panel).
-- **`{prefix}_inset.png`** — a plan-view map of the bbox showing the main axis, the offset envelope, and the marked perpendicular point (opt out with `--no-inset`).
+- **`{prefix}_{field}_mainaxis.png`** — the main-axis curtain (single panel).
+- **`{prefix}_{field}_offsets_n{N}.png`** — along-front curtains with offsets (two columns × `N+1` rows).
+- **`{prefix}_{field}_perp.png`** — the cross-front (perpendicular) curtain (single panel).
+- **`{prefix}_{field}_inset.png`** — a plan-view map of the bbox showing the main axis, the offset envelope, and the marked perpendicular point (opt out with `--no-inset`).
 
 All figures are static matplotlib (Agg backend, dpi 150), matching the repo's existing 2-D companion in [fronts/viz/insets.py](../../fronts/viz/insets.py).
 
@@ -129,7 +129,7 @@ python -m fronts.scripts.fronts_viz_curtain \
 | `--n-isopycnals` | int | `8` | Number of auto-picked isopycnal levels. |
 | `--clim` | LO HI | style clim, else 2/98 pct | Color limits for the (transformed) color field. |
 | `--cmap` | str | field-style cmap | Colormap for the color field. |
-| `--output-prefix` | path | required | Prefix; appends `_mainaxis.png` / `_offsets.png` / `_perp.png` / `_inset.png`. |
+| `--output-prefix` | path | required | Prefix; appends `_{field}_mainaxis.png` / `_{field}_offsets_n{N}.png` / `_{field}_perp.png` / `_{field}_inset.png` (`{field}` = tile variable name, `{N}` = `--n-offsets`). |
 | `--no-inset` | flag | off | Skip the plan-view map inset. |
 
 ## Module map

--- a/docs/viz/fronts_curtain.md
+++ b/docs/viz/fronts_curtain.md
@@ -9,9 +9,9 @@ It reuses the 3-D script's tile-loading, frame-remapping, and front-picking pipe
 Four PNGs per run, all sharing the `--output-prefix`. The filenames embed the field name (`{field}` = the tile variable, e.g. `Ri`) and, for the offsets figure, the offset count (`{N}` = `--n-offsets`):
 
 - **`{prefix}_{field}_mainaxis.png`** — the main-axis curtain (single panel).
-- **`{prefix}_{field}_offsets_n{N}.png`** — along-front curtains with offsets (two columns × `N+1` rows).
+- **`{prefix}_{field}_offsets_n{N}.png`** — along-front curtains: two summary (dilation) rows on top + the `N` individual offset rows (two columns × `N+2` rows).
 - **`{prefix}_{field}_perp.png`** — the cross-front (perpendicular) curtain (single panel).
-- **`{prefix}_{field}_inset.png`** — a plan-view map of the bbox showing the main axis, the offset envelope, and the marked perpendicular point (opt out with `--no-inset`).
+- **`{prefix}_{field}_inset.png`** — a plan-view map of the bbox: the **color field** near-surface slice (same colormap/colorbar as the curtains) with the main axis, the offset envelope, and the marked perpendicular point overlaid (opt out with `--no-inset`).
 
 All figures are static matplotlib (Agg backend, dpi 150), matching the repo's existing 2-D companion in [fronts/viz/insets.py](../../fronts/viz/insets.py).
 
@@ -23,7 +23,13 @@ Plots only the front's **main axis** — the longest end-to-end path through the
 
 ### 2. Along-front curtains with offsets
 
-Two columns — one per side of the front. **Row 0 of both columns is the main-axis curtain itself** (offset 0). Rows 1..N show curtains sampled along paths offset 1..N pixels away from the axis, on the `+normal` side (left column) and `-normal` side (right column). All panels share one color scale for comparability.
+Two columns, `N+2` rows, all sharing one color scale:
+
+- **Row 0** — the main-axis curtain (left) and the **mean over all `2N` offsets** (right). The all-offset mean is a *dilation* of the front: the average field in a band 1..N px to either side.
+- **Row 1** — the mean over the **`+`** offsets (left) and the mean over the **`−`** offsets (right): *directional dilations*, one side of the front each.
+- **Rows 2..N+1** — the individual offsets: offset *r* px on the `+normal` side (left) and `−normal` side (right).
+
+The means are computed on the sampled curtains, column-aligned, with trimmed/looped columns NaN'd *before* averaging, so each averaged column only pools the offsets whose geometry is valid there.
 
 By default each offset line is **trimmed** of self-intersection loops so it contains no crossings — the looped columns on the concave side of a bend are excised ("sewn shut") and render as neutral-gray gaps in the curtain (and as a continuous, crossing-free line on the inset). Pass `--no-trim-offsets` to keep the loops instead and shade them magenta. Off-window/NaN cells always render gray. See [Offsets, trimming, and self-overlap](#offsets-trimming-and-self-overlap).
 
@@ -56,7 +62,7 @@ Identical to the 3-D script: `build_tile_lookup` gives the per-pixel `(j_face, i
 8. **Path metrics** — `curtains.path_metrics` returns per-pixel pixel-distance, great-circle km distance, and unit tangents/normals. `--smooth-normals` smooths *only* the direction field.
 9. **Isopycnal levels** — `pick_isopycnal_levels` brackets the 2/98 percentile of the whole clipped volume (the curtain spans full depth), or uses `--isopycnals`.
 10. **Perpendicular point** — `--perp-point`, else `curtains.pick_extremum_index` over the full-depth axis curtain, with columns whose transect re-crosses the front (`curtains.transect_front_crossings > --perp-max-crossings`) excluded unless `--perp-allow-crossings`.
-11. **Render** — `curtains.figure_main_axis`, `figure_offsets`, `figure_perpendicular`, and the script's `plot_map_inset`.
+11. **Render** — `curtains.figure_main_axis`, `figure_offsets` (with the dilation summary rows), `figure_perpendicular`, and the script's `plot_map_inset` (field background + colorbar).
 
 ## Main-axis extraction
 

--- a/docs/viz/fronts_viz_3d.md
+++ b/docs/viz/fronts_viz_3d.md
@@ -4,6 +4,8 @@
 
 The script also writes a **2-D matplotlib inset** alongside the 3-D PNG with surface σ₀, the front overlaid in red, and lon/lat secondary axes.
 
+> For a copy-paste, end-to-end recipe (headless-cluster env setup, tile generation, and the render command), see the [runbook](fronts_viz_3d_runbook.md).
+
 Optionally, the σ₀ iso-surfaces can be **colored by a second field** (e.g. Richardson number) supplied via `--field-tile` — the geometry stays density-driven while the colors carry the second field interpolated onto each density surface. See [Coloring isopycnals by a second field](#coloring-isopycnals-by-a-second-field-eg-richardson-number).
 
 ## What it produces

--- a/docs/viz/fronts_viz_3d.md
+++ b/docs/viz/fronts_viz_3d.md
@@ -4,6 +4,8 @@
 
 The script also writes a **2-D matplotlib inset** alongside the 3-D PNG with surface σ₀, the front overlaid in red, and lon/lat secondary axes.
 
+Optionally, the σ₀ iso-surfaces can be **colored by a second field** (e.g. Richardson number) supplied via `--field-tile` — the geometry stays density-driven while the colors carry the second field interpolated onto each density surface. See [Coloring isopycnals by a second field](#coloring-isopycnals-by-a-second-field-eg-richardson-number).
+
 ## What it produces
 
 Three files per run:
@@ -14,9 +16,10 @@ Three files per run:
 
 ## Inputs
 
-1. **3-D density tile** — NetCDF written by [llc4320-native-grid-preprocessing/src/dbof/tiles/generate_tile.py](../../../llc4320-native-grid-preprocessing/src/dbof/tiles/generate_tile.py). `sigma0(k, j, i)` on **face-local** axes (k=51, j=720, i=720), 2-D `XC`/`YC`, 1-D `Z`, plus `rect_i_start`/`rect_j_start`/`face_index` provenance.
-2. **Labelled-fronts mask** — global `.npy` on the **rect grid** (12960 × 17280, integer labels, `0 = no front`). For V4 the integer-label file is `labeled_fronts_global_*_V4.npy` (the `*_bfronts.npy` neighbour is boolean only).
-3. **Locator** — either `(--i, --j)` global rect indices, or `(--lat, --lon)` degrees.
+1. **3-D density tile** — NetCDF written by [llc4320-native-grid-preprocessing/src/dbof/tiles/generate_tile.py](../../../llc4320-native-grid-preprocessing/src/dbof/tiles/generate_tile.py). `sigma0(k, j, i)` on **face-local** axes (k=51, j=720, i=720), 2-D `XC`/`YC`, 1-D `Z`, plus `rect_i_start`/`rect_j_start`/`face_index` provenance. **Always drives the geometry.**
+2. **Field tile** *(optional, `--field-tile`)* — a second NetCDF from the same generator, same tile window + timestamp, holding a different property (e.g. `--property richardson` → `Ri(k, j, i)`). Its variable **colors** the density iso-surfaces. See [Coloring isopycnals by a second field](#coloring-isopycnals-by-a-second-field-eg-richardson-number).
+3. **Labelled-fronts mask** — global `.npy` on the **rect grid** (12960 × 17280, integer labels, `0 = no front`). For V4 the integer-label file is `labeled_fronts_global_*_V4.npy` (the `*_bfronts.npy` neighbour is boolean only).
+4. **Locator** — either `(--i, --j)` global rect indices, or `(--lat, --lon)` degrees.
 
 ## Frame handling
 
@@ -40,6 +43,45 @@ The density tile is on face-local axes; the labels mask is on the rect grid. The
 12. **Camera** — `render_3d` sets a **south-east elevated camera** so that i increases left → right and j increases bottom → top on screen. The script captures `pl.camera_position` after `render_3d` and explicitly passes it to `save_with_rst` so the default isometric override inside `save_figure` doesn't reset it. Override per-run with `--cpos JSON`.
 13. **Render & save** — `save_with_rst` from `pv_helpers` writes the 3-D PNG and the interactive HTML in one call; then the script calls `plot_bbox_inset` from [fronts/viz/insets.py](../../fronts/viz/insets.py) for the 2-D companion.
 
+## Coloring isopycnals by a second field (e.g. Richardson number)
+
+The scene **geometry is always density-driven**: the MLD depth clip, the
+isopycnal contour levels, and the tilted front iso-surface are all computed
+from σ₀. Passing `--field-tile` adds a *second* field that is used purely for
+**color**.
+
+How it works: both fields are stamped as point-data arrays on the same
+`RectilinearGrid` (`build_pyvista_grid(extra_fields=...)`). The iso-surfaces
+are still contoured on σ₀ — but VTK's `contour` filter interpolates every
+point array onto the extracted surfaces, so the second field "rides along" and
+can be used as the `add_mesh` color scalar with no resampling code. Each
+isopycnal therefore shows the second field's value *on that density surface*,
+and the tilted front iso-surface is likewise colored by it (so e.g. Ri along
+the front sheet shows directly where the front is shear-unstable).
+
+**Transforms and styles** live in [fronts/viz/field_styles.py](../../fronts/viz/field_styles.py), keyed by the tile variable name (`Ri`, `vorticity`, …). Each style sets a transform (`log10` / `symlog` / `linear`), a raw-value clip, a colormap, a scalar-bar title, and an optional `center` (diverging fields get symmetric color limits). For `Ri` the default is `log10(clip(Ri, 1e-2, 1e4))` with `Ri ≤ 0 → NaN` and a pinned clim of `(-1, 2)`. Unknown fields fall back to a linear transform with percentile limits and a warning.
+
+**NaN handling**: cells that are NaN in the field (land, the tile edge rim, clipped/undefined values such as `Ri ≤ 0`) render in **neutral gray** (`#9e9e9e`) so the iso-surfaces stay hole-free while flagging missing data.
+
+**Interpretation (Ri)**: the gradient Richardson number measures the competition between stratification (stabilising) and vertical shear (destabilising). `Ri < 0.25` (≈ `log10(Ri) < -0.6`) flags shear instability; the default `RdYlBu` colormap with clim `(-1, 2)` keeps that unstable range in the warm half of the bar.
+
+Two-tile example (California Current front, rect tile 330):
+
+```text
+python -m fronts.scripts.fronts_viz_3d \
+    --density-tile density_tile330_20121109T12.nc \
+    --field-tile   Ri_tile330_20121109T12.nc \
+    --labels       labeled_fronts_global_20121109T12_00_00_V4.npy \
+    --i 13142 --j 9956 \
+    --zscale 1.0 \
+    --output /tmp/fronts_viz_3d_calcurrent_Ri.png
+```
+
+`--cmap-volume`, `--clim`, `--field-transform`, and `--field-clip` override the
+registered style if you want to retune. `--mode volume` ignores the field tile
+(volume mode renders σ₀ itself; coloring a σ₀ volume by a second scalar is
+ill-defined).
+
 ## CLI
 
 ```text
@@ -55,7 +97,11 @@ python -m fronts.scripts.fronts_viz_3d \
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
-| `--density-tile` | path | required | NetCDF density tile from `generate_tile.py`. |
+| `--density-tile` | path | required | NetCDF density tile from `generate_tile.py`. Drives geometry. |
+| `--field-tile` | path | none | Optional second tile (same window + timestamp) whose variable colors the iso-surfaces. |
+| `--field-name` | str | auto | Variable inside `--field-tile` (default: the single 3-D variable). |
+| `--field-transform` | `log10`/`symlog`/`linear` | style | Override the field's registered display transform. |
+| `--field-clip` | LO HI | style | Override the field's raw-value clip range (applied before the transform). |
 | `--labels` | path | required | Global integer-labels mask (`.npy` or `.nc`). |
 | `--i / --j` | int | — | Rect-grid pixel coordinates (locator option A). |
 | `--lat / --lon` | float | — | Degrees (locator option B); snapped to the nearest labelled pixel. |
@@ -66,8 +112,8 @@ python -m fronts.scripts.fronts_viz_3d \
 | `--mode` | `isopycnals` / `volume` | `isopycnals` | Background rendering style. |
 | `--isopycnals` | floats | auto-picked | Explicit σ₀ contour values for `--mode isopycnals`. |
 | `--opacity` | `sigmoid` / `linear` / `geom` | `sigmoid` | Opacity transfer for `--mode volume`. |
-| `--clim` | LO HI | mixed-layer 2/98 percentile | σ₀ colour limits. |
-| `--cmap-volume` | str | `viridis` | Colormap for the volume/isopycnal background. See [colormap suggestions](#colormap-suggestions-denser--darker). |
+| `--clim` | LO HI | style clim, else mixed-layer 2/98 percentile | Colour limits for the color scalar (σ₀, or the **transformed** field in `--field-tile` mode). |
+| `--cmap-volume` | str | `viridis` (σ₀) / field-style cmap | Colormap for the volume/isopycnal background. See [colormap suggestions](#colormap-suggestions-denser--darker). |
 | `--cmap-curtain` | str | `magma` | Colormap for the front curtain (only used when `draw_curtain=True`). |
 | `--font-size` | int | 56 | Bounds-axis font size. |
 | `--title-font-size` | int | 60 | Scalar-bar title font size. |
@@ -111,6 +157,7 @@ PyVista's colormap lookup accepts the bare cmocean names (`dense`, `deep`, `gray
 | [fronts/scripts/fronts_viz_3d.py](../../fronts/scripts/fronts_viz_3d.py) | CLI thin wrapper; orchestrates everything. |
 | [fronts/viz/fronts_3d.py](../../fronts/viz/fronts_3d.py) | Front-specific PyVista builders. Re-usable by future 3-D scripts. |
 | [fronts/viz/pv_helpers.py](../../fronts/viz/pv_helpers.py) | Generic PyVista helpers (scientific theme, off-screen Xvfb, scalar bar, PNG + HTML export). |
+| [fronts/viz/field_styles.py](../../fronts/viz/field_styles.py) | Display registry for the color field: per-variable transform / clip / cmap / title / center, plus `apply_transform` and `default_clim`. |
 | [fronts/viz/insets.py](../../fronts/viz/insets.py) | Matplotlib 2-D companion inset. |
 | [fronts/llc/analysis.py](../../fronts/llc/analysis.py) | `mixed_layer_depth` (scalar) and `mixed_layer_depth_field` (vectorised). |
 | [dev/mld/density_utils.py](../../dev/mld/density_utils.py) | Reused for `load_density_tile`, `load_labels_tile`, `build_tile_lookup`, `attach_lonlat_twins`. |
@@ -121,7 +168,7 @@ PyVista's colormap lookup accepts the bare cmocean names (`dense`, `deep`, `gray
 |---|---|
 | `front_bbox_and_crop(labels, label, margin)` | `(j_slice, i_slice)` covering the front's bbox + margin. |
 | `truncate_depth(sigma0, Z, k_mld, n_below)` | Clip the volume to `max(k_mld) + n_below + 1` levels. |
-| `build_pyvista_grid(sigma0, Z, j_slice, i_slice, zscale, mask_2d=None)` | `pv.RectilinearGrid` with σ₀ stamped Fortran-ordered; optional NaN-mask outside `mask_2d`. |
+| `build_pyvista_grid(sigma0, Z, j_slice, i_slice, zscale, mask_2d=None, extra_fields=None)` | `pv.RectilinearGrid` with σ₀ (and any `extra_fields`) stamped Fortran-ordered; optional NaN-mask outside `mask_2d`. σ₀ stays the active scalar so geometry is always density-driven. |
 | `dilate_front_mask(mask, iterations)` | 8-connectivity binary dilation. |
 | `decompose_front_branches(front_mask)` | Custom 8-neighbour DFS; returns a list of per-branch (j,i) polylines. |
 | `build_front_curtain(...)` | `pv.MultiBlock` of vertical sigma0-coloured ribbons per branch. Computed even when off; used by the surface marker. |
@@ -130,7 +177,7 @@ PyVista's colormap lookup accepts the bare cmocean names (`dense`, `deep`, `gray
 | `pick_isopycnals_across_front(sigma0, mask, Z, ...)` | Auto-pick 5 σ₀ levels bracketing the cross-front contrast. |
 | `mixed_layer_clim(sigma0, k_mld, ...)` | 2/98 percentile inside the mixed layer (the default for `--clim`). |
 | `front_volume_clim(sigma0, dilated_mask, ...)` | 2/98 percentile inside a dilated-front 2-D mask (kept for future use; unused in the default path). |
-| `render_3d(grid, curtain, levels, ...)` | Assembles the scene: background, front iso-surface, top marker, axes, SE-up camera, scalar bar. |
+| `render_3d(grid, curtain, levels, ..., color_scalar="sigma0", color_title=None, nan_color="#9e9e9e")` | Assembles the scene: background, front iso-surface, top marker, axes, SE-up camera, scalar bar. Geometry contours σ₀; `color_scalar` selects the coloring array (any stamped field); NaNs render neutral gray. |
 
 ## Smoke-test examples
 
@@ -167,6 +214,7 @@ python -m fronts.scripts.fronts_viz_3d \
 - **v1.4** — dropped the dilation mask from the default path (broader-context iso-surfaces back); replaced the vertical-sheet curtain with a single **tilted σ₀ iso-surface** via `build_front_isosurface`; inset figsize bumped (7×6 → 10×8).
 - **v1.5** — explicit **south-east elevated camera** so i goes left→right and j goes bottom→top; fonts bumped (40/44/32 → 56/60/44); top marker tube radius reduced (1.5 → 0.8) and opacity dropped (1.0 → 0.6).
 - **v1.6** — `--cmap-volume` suggestions for "dark = dense" (recommend `dense`); CLI font knobs (`--font-size`, `--title-font-size`, `--label-font-size`); enlarged scalar bar (width 0.05 → 0.08, height 0.42 → 0.50) and shifted left of the viewport edge so the title doesn't clip.
+- **v1.7** — **dual-field coloring**: geometry stays σ₀-driven while an optional `--field-tile` (e.g. a Richardson-number tile) colors the iso-surfaces via VTK contour pass-through interpolation. New `field_styles.py` display registry (per-variable transform / clip / cmap / title / center); `build_pyvista_grid(extra_fields=...)` and `render_3d(color_scalar=, color_title=, nan_color=)`; NaN cells (land / edge rim / clipped) render neutral gray `#9e9e9e`. New flags `--field-tile`, `--field-name`, `--field-transform`, `--field-clip`; `--clim`/`--cmap-volume` now apply to the color scalar. Fully backward compatible — without `--field-tile` the scene is unchanged.
 
 ## Known follow-ups
 

--- a/docs/viz/fronts_viz_3d_runbook.md
+++ b/docs/viz/fronts_viz_3d_runbook.md
@@ -71,7 +71,7 @@ export DISPLAY=dummy
 
 # Data locations.
 export TILES=/mnt/tank/Oceanography/data/OGCM/LLC/Fronts/V4/20121109_120000/tiles
-export LABELS=/mnt/tank/Oceanography/data/OGCM/LLC/Fronts/V4/20121109_120000/labeled_fronts_global_20121109T12_00_00_V4.npy
+export LABELS=/mnt/tank/Oceanography/data/OGCM/LLC/Fronts/V4/20121109_120000/labeled_fronts_global_20121109T12_00_00_V4_bin_D.npy
 export OUTDIR=/mnt/tank/Oceanography/data/OGCM/LLC/Fronts/lohoff/fronts_viz
 mkdir -p "$OUTDIR"
 ```

--- a/docs/viz/fronts_viz_3d_runbook.md
+++ b/docs/viz/fronts_viz_3d_runbook.md
@@ -1,0 +1,164 @@
+# Runbook — Ri-colored 3-D front viz on a headless cluster
+
+End-to-end recipe for producing the interactive 3-D HTML (isopycnal surfaces
+colored by Richardson number) on a headless Linux node with **no X server and
+no admin rights**. Pairs with the reference doc
+[`fronts_viz_3d.md`](fronts_viz_3d.md) (flags, algorithm) and the tile docs in
+the preprocessing repo
+([`llc4320-native-grid-preprocessing/docs/Tiles.md`](../../../llc4320-native-grid-preprocessing/docs/Tiles.md)).
+
+Two things have different lifetimes, and conflating them is the usual
+stumbling block:
+
+| Thing | Lifetime | Redo when? |
+|-------|----------|------------|
+| The conda env + OSMesa VTK swap | **persists on disk** | only if you delete/rebuild the env, or a later `conda install` clobbers `vtk` |
+| The `export DISPLAY=… / TILES=… / …` shell vars | **per shell session** | every new shell — so keep them in a file you `source` (below) |
+
+---
+
+## 0. One-time: headless rendering env (OSMesa)
+
+The default PyVista/VTK build needs an OpenGL context (X server / GPU). On a
+headless node with neither, swap in the **OSMesa** (software, CPU) VTK build.
+Do it in a *clone* so the original env stays intact:
+
+```bash
+conda create --name llcngp_osmesa --clone llcngp
+conda activate llcngp_osmesa
+
+# Match the OSMesa wheel to the VTK version PyVista already expects:
+python -c "import vtk; print(vtk.VTK_VERSION)"        # note e.g. 9.3.1
+
+pip uninstall -y vtk           # remove a pip-installed vtk, if any
+conda remove --force -y vtk    # remove a conda-installed vtk without pulling pyvista
+pip install --extra-index-url https://wheels.vtk.org "vtk-osmesa==<VERSION_ABOVE>"
+
+# sanity check — should print a byte count, no display error:
+python -c "import pyvista as pv; pv.OFF_SCREEN=True; p=pv.Plotter(off_screen=True); p.add_mesh(pv.Sphere()); print('ok', len(p.screenshot(return_img=True)))"
+```
+
+Record what you installed so the version is pinned for future-you:
+
+```bash
+pip freeze | grep -i vtk        # e.g. vtk-osmesa==9.3.1
+```
+
+(Why this isn't a `pip install -e .` dependency: the right GL backend —
+OSMesa / GLX / EGL / Xvfb — is machine-specific, and `vtk-osmesa` is a
+conflicting drop-in for `vtk` served from a non-PyPI index. Pinning it in the
+package would break every non-headless install. It's a deployment choice, not
+a code dependency.)
+
+---
+
+## 1. Per-session env
+
+Save this as `env_fronts_viz.sh` (edit the paths once) and `source` it at the
+start of each session — that's all you re-do next week:
+
+```bash
+# env_fronts_viz.sh  --  source this, don't execute it
+conda activate llcngp_osmesa
+
+# Lets dev/mld/density_utils.py find the preprocessing repo's tile_mapping.
+# (Redundant if the preprocessing repo is `pip install -e`'d, but harmless.)
+export LLC4320_PREPROC_SRC=/home/lhoffma2/git/llc4320-native-grid-preprocessing/
+
+# Any non-empty value: makes ensure_display() skip the (removed) start_xvfb;
+# OSMesa ignores DISPLAY entirely.
+export DISPLAY=dummy
+
+# Data locations.
+export TILES=/mnt/tank/Oceanography/data/OGCM/LLC/Fronts/V4/20121109_120000/tiles
+export LABELS=/mnt/tank/Oceanography/data/OGCM/LLC/Fronts/V4/20121109_120000/labeled_fronts_global_20121109T12_00_00_V4.npy
+export OUTDIR=/mnt/tank/Oceanography/data/OGCM/LLC/Fronts/lohoff/fronts_viz
+mkdir -p "$OUTDIR"
+```
+
+```bash
+source env_fronts_viz.sh
+```
+
+---
+
+## 2. Generate the tiles (reads from S3 — needs network)
+
+The viz needs **two** tiles from the same window + timestamp: density drives
+the geometry, Ri drives the color. Passing a directory to `--output` uses the
+default per-property filename inside it.
+
+```bash
+# geometry tile (sigma0) — skip if it already exists in $TILES
+python -m dbof.tiles.generate_tile \
+    --i 13142 --j 9956 --timestamp '2012-11-09 12:00:00' \
+    --property density --output "$TILES"
+# -> $TILES/density_tile330_20121109T12.nc
+
+# color tile (Ri)
+python -m dbof.tiles.generate_tile \
+    --i 13142 --j 9956 --timestamp '2012-11-09 12:00:00' \
+    --property richardson --output "$TILES"
+# -> $TILES/Ri_tile330_20121109T12.nc
+```
+
+Any registered property works for `--field-tile` color (see the table in
+`Tiles.md`): `vorticity`, `okubo_weiss`, `frontogenesis`, `N2`, … — just
+generate that tile with `--property <name>`.
+
+---
+
+## 3. Render the interactive HTML
+
+```bash
+python -m fronts.scripts.fronts_viz_3d \
+    --density-tile "$TILES/density_tile330_20121109T12.nc" \
+    --field-tile   "$TILES/Ri_tile330_20121109T12.nc" \
+    --labels       "$LABELS" \
+    --i 13142 --j 9956 --zscale 1.0 \
+    --output           "$OUTDIR/fronts_viz_3d_calcurrent_Ri.png" \
+    --interactive-html "$OUTDIR/fronts_viz_3d_calcurrent_Ri.html"
+```
+
+Writes the interactive HTML, a 3-D PNG, and a 2-D inset PNG into `$OUTDIR`.
+Geometry = isopycnals (σ₀); color = `log10(clip(Ri, 1e-2, 1e4))`. Cells where
+Ri ≤ 0 or NaN (land, the 1-px tile edge rim, zero-shear) render neutral gray.
+
+---
+
+## 4. Configuring the colormap / scaling
+
+Per run (overrides the registered style):
+
+```bash
+--cmap-volume RdBu_r        # any matplotlib / cmocean name
+--clim -1 2                 # color limits, in the *transformed* (log10) space
+--field-clip 1e-3 1e3       # raw-Ri clip before the transform
+--field-transform symlog    # log10 | symlog | linear
+```
+
+Persistent default — edit the `"Ri"` entry of
+[`fronts/viz/field_styles.py`](../../fronts/viz/field_styles.py):
+
+```python
+"Ri": FieldStyle(
+    transform="log10", clip=(1e-2, 1e4), cmap="RdYlBu",
+    title="log10(Ri)", clim=(-1.0, 2.0),
+),
+```
+
+That one entry controls colormap, color limits, transform, raw clip, and the
+scalar-bar title for every Ri render. Diverging fields (vorticity, OW, …) set
+`center=0.0` for symmetric limits.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---------|-------------|
+| `module 'pyvista' has no attribute 'start_xvfb'` | No `$DISPLAY` and PyVista ≥ 0.44. Set `export DISPLAY=dummy` (step 1) — OSMesa needs no real display. |
+| `Could not import 'tile_mapping' …` | `LLC4320_PREPROC_SRC` unset and preprocessing repo not installed. Set the var (step 1) or `pip install -e` that repo. |
+| `Tile provenance mismatch …` | The density and field tiles are from different windows/timestamps. Regenerate both with the same `--i/--j/--timestamp`. |
+| OpenGL / `libGL` error (not a display error) | Env missing Mesa: `conda install -c conda-forge mesalib`. |
+| HTML opens but surfaces are mostly gray | Expected where Ri ≤ 0 / NaN; if *everything* is gray, the field tile may be all-NaN — check the QA of the Ri tile. |

--- a/fronts/properties/defs.py
+++ b/fronts/properties/defs.py
@@ -129,7 +129,7 @@ ocean_field_defs = {
         subset='frontal_structure',
     ),
     'gradtheta2': dict(
-        units='(K/m)²',
+        units='(°C/m)²',
         equation='|∇θ|² = (∂θ/∂x)² + (∂θ/∂y)²',
         description='Squared temperature gradient magnitude',
         subset='frontal_structure',

--- a/fronts/scripts/fronts_viz_3d.py
+++ b/fronts/scripts/fronts_viz_3d.py
@@ -7,6 +7,9 @@ Inputs:
     (sigma0(k, j, i) on **face-local** axes, plus XC, YC, Z and the
     rect_i_start / rect_j_start / face_index / tile_index provenance
     fields).
+  * optionally, a second **field tile** (same generator, same tile window
+    + timestamp -- e.g. ``--property richardson``) whose variable colors
+    the density iso-surfaces (see "Dual-field coloring" below).
   * a global labelled-fronts mask (``.npy`` or ``.nc``) on the **rect
     grid** (shape 12960 x 17280, integer labels, 0 = no front).
   * a locator: either ``--i / --j`` (rect-grid pixel coordinates) or
@@ -21,13 +24,24 @@ render, with the front itself overlaid as a sigma0-coloured "curtain".
 A companion 2-D matplotlib inset showing surface sigma0 + the front +
 lon/lat ticks is written next to the 3-D PNG by default.
 
+Dual-field coloring (``--field-tile``)
+--------------------------------------
+The scene *geometry* is always density-driven: MLD depth clip, isopycnal
+levels, and the tilted front iso-surface all come from sigma0.  When
+``--field-tile`` is supplied, the second field (transformed per
+``fronts/viz/field_styles.py`` -- e.g. ``log10(clip(Ri, 1e-2, 1e4))``)
+is stamped on the same grid and used purely for *color*: VTK interpolates
+it onto every extracted sigma0 iso-surface.  NaNs (land, edge rim,
+clipped/undefined values) render neutral gray.
+
 CLI usage
 ---------
     python -m fronts.scripts.fronts_viz_3d \\
         --density-tile density_tile330_20121109T12.nc \\
+        --field-tile   Ri_tile330_20121109T12.nc \\
         --labels       LLC4320_2012-11-09T12_00_00_V4_bfronts.npy \\
         --i 13170 --j 9950 \\
-        --output       fronts_viz_3d_californiacurrent.png
+        --output       fronts_viz_3d_californiacurrent_Ri.png
 """
 
 # stdlib
@@ -49,6 +63,8 @@ if str(_DEV_MLD) not in sys.path:
     sys.path.insert(0, str(_DEV_MLD))
 from density_utils import (  # noqa: E402
     load_density_tile,
+    load_tile,
+    check_tiles_consistent,
     load_labels_tile,
     tile_scalar,
     build_tile_lookup,
@@ -72,6 +88,11 @@ from fronts.viz.fronts_3d import (  # noqa: E402
 )
 from fronts.viz.insets import plot_bbox_inset  # noqa: E402
 from fronts.viz.pv_helpers import save_with_rst  # noqa: E402
+from fronts.viz.field_styles import (  # noqa: E402
+    get_style,
+    apply_transform,
+    NAN_COLOR,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -102,6 +123,25 @@ def parse_args(argv=None) -> argparse.Namespace:
                    help="NetCDF density tile produced by generate_tile.py.")
     p.add_argument("--labels", type=Path, required=True,
                    help="Global labelled-fronts mask (.npy or .nc).")
+
+    # Optional second field for coloring (geometry stays sigma0-driven).
+    p.add_argument("--field-tile", type=Path, default=None,
+                   help="Optional NetCDF field tile (same generator, same "
+                        "tile window + timestamp, e.g. --property "
+                        "richardson).  Its variable colors the sigma0 "
+                        "iso-surfaces; geometry stays density-driven.")
+    p.add_argument("--field-name", type=str, default=None,
+                   help="Variable name inside --field-tile (default: "
+                        "auto-detect the single 3-D variable).")
+    p.add_argument("--field-transform",
+                   choices=["log10", "symlog", "linear"], default=None,
+                   help="Override the field's registered display transform "
+                        "(see fronts/viz/field_styles.py).")
+    p.add_argument("--field-clip", type=float, nargs=2, default=None,
+                   metavar=("LO", "HI"),
+                   help="Override the field's registered raw-value clip "
+                        "range (applied before the transform; e.g. for Ri "
+                        "the default is 1e-2 1e4).")
 
     # Locator -- exactly one pair must be supplied.
     p.add_argument("--i", type=int, default=None,
@@ -138,15 +178,19 @@ def parse_args(argv=None) -> argparse.Namespace:
                    help="Opacity transfer for --mode volume.")
     p.add_argument("--clim", type=float, nargs=2, default=None,
                    metavar=("LO", "HI"),
-                   help="sigma0 colour limits (default 2/98 percentile).")
+                   help="Colour limits for the color scalar (sigma0, or the "
+                        "transformed field in --field-tile mode; default: "
+                        "registered style clim, else mixed-layer 2/98 "
+                        "percentile).")
     p.add_argument(
-        "--cmap-volume", type=str, default="viridis",
+        "--cmap-volume", type=str, default=None,
         help=(
             "Colormap for the volume/isopycnal background.  Suggestions "
             "where DENSER water is DARKER (more natural for sigma0): "
             "dense, deep, gray (cmocean, bare names accepted by PyVista), "
             "Blues, bone, viridis_r, cividis_r, magma_r, plasma_r.  "
-            "Default 'viridis' (denser=lighter)."
+            "Default: 'viridis' for sigma0 coloring; the field's "
+            "registered style cmap in --field-tile mode."
         ),
     )
     p.add_argument("--cmap-curtain", type=str, default="magma",
@@ -358,6 +402,38 @@ def main(argv=None) -> None:
     XC_face = ds["XC"].values  # (J_face, I_face)
     YC_face = ds["YC"].values  # (J_face, I_face)
 
+    # ---------- Optional color-field tile (e.g. Ri) ----------
+    # Geometry stays sigma0-driven; this field is used purely for color.
+    field_name = None
+    field_face = None
+    field_style = None
+    if args.field_tile is not None:
+        log.info("Loading field tile %s", args.field_tile)
+        ds_field = load_tile(args.field_tile, var_name=args.field_name)
+        check_tiles_consistent(
+            ds, ds_field, label_a="--density-tile", label_b="--field-tile",
+        )
+        field_name = ds_field.attrs["tile_var_name"]
+        field_face = ds_field[field_name].values  # (K, J_face, I_face)
+        if field_face.shape != sigma0_face.shape:
+            raise SystemExit(
+                f"--field-tile variable '{field_name}' has shape "
+                f"{field_face.shape}, expected {sigma0_face.shape} (must "
+                "match the density tile)."
+            )
+        field_style = get_style(field_name)
+        log.info(
+            "Coloring by %s (transform=%s, clip=%s)",
+            field_name,
+            args.field_transform or field_style.transform,
+            args.field_clip or field_style.clip,
+        )
+        if args.mode == "volume":
+            log.warning(
+                "--field-tile coloring applies to --mode isopycnals only; "
+                "volume mode renders sigma0 itself."
+            )
+
     log.info("Building tile lookup (face -> rect-tile-local)")
     j_tile_lookup, i_tile_lookup = build_tile_lookup(
         rect_i_start, rect_j_start, face_index,
@@ -374,6 +450,9 @@ def main(argv=None) -> None:
     sigma0_rect = remap_to_rect(sigma0_face, j_tile_lookup, i_tile_lookup)
     XC_rect = remap_to_rect(XC_face, j_tile_lookup, i_tile_lookup)
     YC_rect = remap_to_rect(YC_face, j_tile_lookup, i_tile_lookup)
+    field_rect = None
+    if field_face is not None:
+        field_rect = remap_to_rect(field_face, j_tile_lookup, i_tile_lookup)
 
     # ---------- Pick the front ----------
     if args.locator_kind == "ij":
@@ -405,6 +484,18 @@ def main(argv=None) -> None:
     sigma0_clipped, Z_clipped, k_clip = truncate_depth(
         sigma0_cropped, Z, k_mld, n_below=args.n_below,
     )
+
+    # Color field: same crop + depth clip, then the display transform
+    # (e.g. log10(clip(Ri, 1e-2, 1e4)) with Ri <= 0 -> NaN).
+    field_display = None
+    if field_rect is not None:
+        field_clipped = field_rect[:, j_slice, i_slice][:k_clip]
+        field_display = apply_transform(
+            field_clipped, field_style,
+            clip_override=(tuple(args.field_clip)
+                           if args.field_clip is not None else None),
+            transform_override=args.field_transform,
+        )
     log.info(
         "MLD inside bbox: deepest k=%d (z=%.1f m); clipping to k=%d (z=%.1f m)",
         int(np.nanmax(k_mld)) if (k_mld >= 0).any() else -1,
@@ -432,21 +523,56 @@ def main(argv=None) -> None:
     # ---------- Default clim: 2/98 percentile of the mixed layer ----------
     # Restricting to the mixed layer keeps the iso-surfaces colourful
     # (most cross-front contrast lives there) without washing out the
-    # broader bbox context.
-    if args.clim is None:
+    # broader bbox context.  In dual-field mode the clim applies to the
+    # *transformed color field*; precedence is --clim > the field's
+    # registered style clim > mixed-layer percentiles (symmetrised about
+    # the style's center for diverging fields).
+    if args.clim is not None:
+        clim = tuple(args.clim)
+    elif field_display is not None:
+        style_clim_ok = (
+            field_style.clim is not None
+            and args.field_transform is None
+            and args.field_clip is None
+        )
+        if style_clim_ok:
+            clim = tuple(field_style.clim)
+            log.info("Style clim for %s = (%.4g, %.4g)", field_name, *clim)
+        else:
+            clim = mixed_layer_clim(field_display, k_mld)
+            if field_style.center is not None:
+                span = max(abs(clim[0] - field_style.center),
+                           abs(clim[1] - field_style.center))
+                clim = (field_style.center - span, field_style.center + span)
+            log.info(
+                "Auto clim for %s = (%.4g, %.4g) (mixed layer)",
+                field_name, *clim,
+            )
+    else:
         clim = mixed_layer_clim(sigma0_clipped, k_mld)
         log.info(
             "Auto clim = (%.4f, %.4f) kg m^-3 (mixed layer)", *clim,
         )
+
+    # Colormap: explicit flag wins; otherwise the field's registered style
+    # cmap in dual-field mode, else the classic viridis default.
+    if args.cmap_volume is not None:
+        cmap_volume = args.cmap_volume
+    elif field_style is not None:
+        cmap_volume = field_style.cmap
     else:
-        clim = tuple(args.clim)
+        cmap_volume = "viridis"
 
     # ---------- PyVista scene ----------
     # No mask -> iso-surfaces are rendered over the whole cropped bbox
     # ("waters near the front") -- restoring the v1.2 behaviour the user
     # asked back for.
+    extra_fields = (
+        {field_name: field_display} if field_display is not None else None
+    )
     grid = build_pyvista_grid(
         sigma0_clipped, Z_clipped, j_slice, i_slice, zscale=args.zscale,
+        extra_fields=extra_fields,
     )
 
     # Build a single front-iso-surface: picking the median of the cross-
@@ -481,13 +607,21 @@ def main(argv=None) -> None:
     if args.label_font_size is not None:
         font_kwargs["label_font_size"] = args.label_font_size
 
+    color_kwargs = {}
+    if field_display is not None:
+        color_kwargs = dict(
+            color_scalar=field_name,
+            color_title=field_style.title or field_name,
+            nan_color=NAN_COLOR,
+        )
     pl = render_3d(
         grid, curtain, levels,
         mode=args.mode, clim=clim,
-        cmap_volume=args.cmap_volume, cmap_curtain=args.cmap_curtain,
+        cmap_volume=cmap_volume, cmap_curtain=args.cmap_curtain,
         opacity=args.opacity, zscale=args.zscale, show=args.show,
         top_marker=top_marker,
         front_iso=front_iso,
+        **color_kwargs,
         **font_kwargs,
     )
 

--- a/fronts/scripts/fronts_viz_3d.py
+++ b/fronts/scripts/fronts_viz_3d.py
@@ -410,9 +410,13 @@ def main(argv=None) -> None:
     if args.field_tile is not None:
         log.info("Loading field tile %s", args.field_tile)
         ds_field = load_tile(args.field_tile, var_name=args.field_name)
-        check_tiles_consistent(
-            ds, ds_field, label_a="--density-tile", label_b="--field-tile",
-        )
+        try:
+            check_tiles_consistent(
+                ds, ds_field,
+                label_a="--density-tile", label_b="--field-tile",
+            )
+        except ValueError as err:
+            raise SystemExit(str(err)) from err
         field_name = ds_field.attrs["tile_var_name"]
         field_face = ds_field[field_name].values  # (K, J_face, I_face)
         if field_face.shape != sigma0_face.shape:

--- a/fronts/scripts/fronts_viz_curtain.py
+++ b/fronts/scripts/fronts_viz_curtain.py
@@ -34,12 +34,12 @@ Inputs mirror ``fronts_viz_3d``:
 
 CLI usage
 ---------
-    python -m fronts.scripts.fronts_viz_curtain \\
-        --density-tile density_tile330_20121109T12.nc \\
-        --field-tile   Ri_tile330_20121109T12.nc \\
-        --labels       labeled_fronts_global_20121109T12_00_00_V4.npy \\
-        --i 13142 --j 9956 \\
-        --n-offsets 3 --perp-half-width 30 \\
+    python -m fronts.scripts.fronts_viz_curtain \
+        --density-tile density_tile330_20121109T12.nc \
+        --field-tile   Ri_tile330_20121109T12.nc \
+        --labels       labeled_fronts_global_20121109T12_00_00_V4.npy \
+        --i 13142 --j 9956 \
+        --n-offsets 3 --perp-half-width 10 \
         --output-prefix /tmp/calcurrent_curtain
 """
 

--- a/fronts/scripts/fronts_viz_curtain.py
+++ b/fronts/scripts/fronts_viz_curtain.py
@@ -403,8 +403,12 @@ def main(argv=None) -> None:
             f"{field_face.shape}, expected {sigma0_face.shape}."
         )
     field_style = get_style(field_name)
-    log.info("Coloring curtains by %s (transform=%s)",
-             field_name, args.field_transform or field_style.transform)
+    # Human-readable field name for titles (e.g. "richardson_number"); fall
+    # back to the tile variable name (e.g. "Ri") when no long_name attr.
+    field_label = ds_field[field_name].attrs.get("long_name", field_name)
+    log.info("Coloring curtains by %s (%s, transform=%s)",
+             field_name, field_label,
+             args.field_transform or field_style.transform)
 
     # ---------- Frame remap ----------
     log.info("Building tile lookup + remapping to rect-tile-local frame")
@@ -542,7 +546,7 @@ def main(argv=None) -> None:
         color_display, sigma0_clipped, Z_clipped, axis_path, metrics, out_main,
         levels=levels, clim=clim, cmap=cmap, color_title=color_title,
         mld_curtain=mld_curtain, mark_index=perp_idx,
-        title=f"Main-axis curtain (front {label})",
+        title=f"Main-axis curtain — {field_label} (front {label})",
     )
     log.info("Wrote %s", out_main)
 
@@ -551,7 +555,8 @@ def main(argv=None) -> None:
         args.n_offsets, out_off,
         levels=levels, clim=clim, cmap=cmap, color_title=color_title,
         mark_index=perp_idx, trim=args.trim_offsets,
-        title=f"Along-front curtains + offsets (front {label})",
+        title=(f"Along-front curtains — {field_label}, "
+               f"{args.n_offsets} offsets/side (front {label})"),
     )
     log.info("Wrote %s", out_off)
 
@@ -560,7 +565,8 @@ def main(argv=None) -> None:
         args.perp_half_width, out_perp,
         XC_rect=XC_crop, YC_rect=YC_crop,
         levels=levels, clim=clim, cmap=cmap, color_title=color_title,
-        title=f"Cross-front curtain at axis col {perp_idx} (front {label})",
+        title=(f"Cross-front curtain — {field_label} "
+               f"at axis col {perp_idx} (front {label})"),
     )
     log.info("Wrote %s", out_perp)
 

--- a/fronts/scripts/fronts_viz_curtain.py
+++ b/fronts/scripts/fronts_viz_curtain.py
@@ -5,21 +5,23 @@ This is the 2-D companion to ``fronts/scripts/fronts_viz_3d.py``.  It reuses
 that script's tile-loading / remapping / front-picking pipeline, then -- instead
 of a 3-D PyVista scene -- produces three static matplotlib curtain figures:
 
-1. **Main-axis curtain** (``{prefix}_mainaxis.png``) -- a vertical
+1. **Main-axis curtain** (``{prefix}_{field}_mainaxis.png``) -- a vertical
    cross-section along the front's main axis (longest end-to-end path through
    the skeleton, side branches dropped).  x = distance along the front,
    y = depth, color = a configurable field (default ``Ri``), with isopycnal
    (sigma0) contours overlaid.
-2. **Along-front curtains with offsets** (``{prefix}_offsets.png``) -- two
-   columns (the two sides of the front); row 0 of each is the main axis, rows
-   below are offsets 1..N pixels away.  Offset columns whose geometry
-   self-overlaps (concave bends / skeleton noise) are shaded.
-3. **Cross-front curtain** (``{prefix}_perp.png``) -- a perpendicular transect
-   cut at a chosen point along the main axis (default: the field extremum over
-   the full depth range), same curtain style.
+2. **Along-front curtains with offsets** (``{prefix}_{field}_offsets_n{N}.png``)
+   -- two columns (the two sides of the front); row 0 of each is the main
+   axis, rows below are offsets 1..N pixels away.  Offset columns whose
+   geometry self-overlaps (concave bends / skeleton noise) are trimmed.
+3. **Cross-front curtain** (``{prefix}_{field}_perp.png``) -- a perpendicular
+   transect cut at a chosen point along the main axis (default: the field
+   extremum over the full depth range), same curtain style.
 
-A 2-D **map-view inset** (``{prefix}_inset.png``) shows the bbox with the main
-axis, the offset envelope, and the marked perpendicular point.
+A 2-D **map-view inset** (``{prefix}_{field}_inset.png``) shows the bbox with
+the main axis, the offset envelope, and the marked perpendicular point.  The
+``{field}`` token is the tile variable name (e.g. ``Ri``); ``{N}`` is
+``--n-offsets``.
 
 Inputs mirror ``fronts_viz_3d``:
   * a 3-D **density tile** NetCDF (``sigma0(k, j, i)``, face-local) -- drives
@@ -202,7 +204,9 @@ def parse_args(argv=None) -> argparse.Namespace:
     # Output.
     p.add_argument("--output-prefix", type=Path, required=True,
                    help="Output path prefix; the script appends "
-                        "_mainaxis.png / _offsets.png / _perp.png / _inset.png.")
+                        "_{field}_mainaxis.png / _{field}_offsets_n{N}.png / "
+                        "_{field}_perp.png / _{field}_inset.png, where {field} "
+                        "is the tile variable name and {N} is --n-offsets.")
     p.add_argument("--no-inset", action="store_true",
                    help="Skip the map-view inset figure.")
 
@@ -369,8 +373,9 @@ def main(argv=None) -> None:
 
     Side effects
     ------------
-    Writes ``{prefix}_mainaxis.png``, ``{prefix}_offsets.png``,
-    ``{prefix}_perp.png`` and (unless ``--no-inset``) ``{prefix}_inset.png``.
+    Writes ``{prefix}_{field}_mainaxis.png``,
+    ``{prefix}_{field}_offsets_n{N}.png``, ``{prefix}_{field}_perp.png`` and
+    (unless ``--no-inset``) ``{prefix}_{field}_inset.png``.
     """
     logging.basicConfig(
         level=logging.INFO,
@@ -403,9 +408,13 @@ def main(argv=None) -> None:
             f"{field_face.shape}, expected {sigma0_face.shape}."
         )
     field_style = get_style(field_name)
-    # Human-readable field name for titles (e.g. "richardson_number"); fall
-    # back to the tile variable name (e.g. "Ri") when no long_name attr.
+    # Human-readable field name (e.g. "richardson_number"); fall back to the
+    # tile variable name (e.g. "Ri") when no long_name attr.
     field_label = ds_field[field_name].attrs.get("long_name", field_name)
+    # Filesystem-safe token built into the output filenames (e.g. "Ri", "wB").
+    field_tag = "".join(
+        c if (c.isalnum() or c in "._-") else "_" for c in str(field_name)
+    ).strip("_") or "field"
     log.info("Coloring curtains by %s (%s, transform=%s)",
              field_name, field_label,
              args.field_transform or field_style.transform)
@@ -537,10 +546,14 @@ def main(argv=None) -> None:
     mld_curtain = mld_depth_2d[jj, ii]
 
     # ---------- Render the three figures ----------
+    # Filenames carry the field tag, and the offsets figure also carries the
+    # offset count: {prefix}_{field}_mainaxis.png, {prefix}_{field}_offsets_n{N}.png,
+    # {prefix}_{field}_perp.png.
     prefix = args.output_prefix
-    out_main = prefix.with_name(prefix.name + "_mainaxis.png")
-    out_off = prefix.with_name(prefix.name + "_offsets.png")
-    out_perp = prefix.with_name(prefix.name + "_perp.png")
+    out_main = prefix.with_name(f"{prefix.name}_{field_tag}_mainaxis.png")
+    out_off = prefix.with_name(
+        f"{prefix.name}_{field_tag}_offsets_n{args.n_offsets}.png")
+    out_perp = prefix.with_name(f"{prefix.name}_{field_tag}_perp.png")
 
     curtains.figure_main_axis(
         color_display, sigma0_clipped, Z_clipped, axis_path, metrics, out_main,
@@ -555,8 +568,7 @@ def main(argv=None) -> None:
         args.n_offsets, out_off,
         levels=levels, clim=clim, cmap=cmap, color_title=color_title,
         mark_index=perp_idx, trim=args.trim_offsets,
-        title=(f"Along-front curtains — {field_label}, "
-               f"{args.n_offsets} offsets/side (front {label})"),
+        title=f"Along-front curtains + offsets — {field_label} (front {label})",
     )
     log.info("Wrote %s", out_off)
 
@@ -572,7 +584,7 @@ def main(argv=None) -> None:
 
     # ---------- Map-view inset ----------
     if not args.no_inset:
-        out_inset = prefix.with_name(prefix.name + "_inset.png")
+        out_inset = prefix.with_name(f"{prefix.name}_{field_tag}_inset.png")
         side_a, side_b = curtains.offset_paths(
             axis_path, metrics["normals"], args.n_offsets,
         )

--- a/fronts/scripts/fronts_viz_curtain.py
+++ b/fronts/scripts/fronts_viz_curtain.py
@@ -429,7 +429,10 @@ def main(argv=None) -> None:
 
     log.info("Loading field tile %s", args.field_tile)
     ds_field = load_tile(args.field_tile, var_name=args.field_name)
-    check_tiles_consistent(ds, ds_field, "--density-tile", "--field-tile")
+    try:
+        check_tiles_consistent(ds, ds_field, "--density-tile", "--field-tile")
+    except ValueError as err:
+        raise SystemExit(str(err)) from err
     field_name = ds_field.attrs["tile_var_name"]
     field_face = ds_field[field_name].values
     if field_face.shape != sigma0_face.shape:

--- a/fronts/scripts/fronts_viz_curtain.py
+++ b/fronts/scripts/fronts_viz_curtain.py
@@ -150,10 +150,24 @@ def parse_args(argv=None) -> argparse.Namespace:
                         "(default 30; total length 2*N+1).")
     p.add_argument("--perp-point", type=int, default=None,
                    help="Main-axis column index for the perpendicular "
-                        "transect.  Default: the field-extremum column.")
+                        "transect.  Default: the field-extremum column.  Use "
+                        "--list-perp-candidates to see column -> (i,j) values.")
     p.add_argument("--extremum", choices=["min", "max"], default="min",
                    help="Whether the default perpendicular point is the field "
                         "minimum (default; e.g. lowest Ri) or maximum.")
+    p.add_argument("--perp-max-crossings", type=int, default=1,
+                   help="When auto-picking the perpendicular point, only "
+                        "consider main-axis columns whose transect crosses the "
+                        "front at most this many times (default 1 = a clean "
+                        "single crossing, away from the front's squiggly "
+                        "self-overlapping parts).")
+    p.add_argument("--perp-allow-crossings", action="store_true",
+                   help="Disable the crossing filter above; auto-pick the "
+                        "field extremum anywhere along the axis.")
+    p.add_argument("--list-perp-candidates", action="store_true",
+                   help="Log the main-axis column index, (i,j), along-path km, "
+                        "and transect crossing-count for each column, then "
+                        "continue.  Helps choose --perp-point.")
 
     # Smoothing of the direction field (NOT the main-axis columns).
     p.add_argument("--smooth-normals", action="store_true",
@@ -162,6 +176,14 @@ def parse_args(argv=None) -> argparse.Namespace:
                         "default).  Does NOT move the main-axis columns.")
     p.add_argument("--smooth-window", type=int, default=5,
                    help="Odd pixel window for --smooth-normals (default 5).")
+    p.add_argument("--no-trim-offsets", dest="trim_offsets",
+                   action="store_false",
+                   help="Keep self-intersection loops in the offset lines "
+                        "(shaded magenta) instead of trimming them.  By "
+                        "default each offset polyline is 'sewn' shut so it "
+                        "contains no crossings (looped columns become gray "
+                        "gaps in the curtain).")
+    p.set_defaults(trim_offsets=True)
 
     # Display.
     p.add_argument("--isopycnals", type=float, nargs="+", default=None,
@@ -246,6 +268,7 @@ def plot_map_inset(
     i_slice: slice,
     output_path: Path,
     *,
+    trim: bool = True,
     title: str = "",
 ) -> Path:
     """Plan-view map of the bbox: surface field + axis + offsets + perp point.
@@ -297,17 +320,25 @@ def plot_map_inset(
     def _plot(p, **kw):
         ax.plot(p[:, 1] + di, p[:, 0] + dj, **kw)
 
+    def _plot_offset(p, **kw):
+        # "Sew" the offset shut: drop self-intersection loops so the drawn line
+        # has no crossings (matches the trimmed curtain).
+        if trim:
+            keep = curtains.trim_offset_loops(p)
+            p = p[keep]
+        _plot(p, **kw)
+
     # All front pixels (faint), then the main axis (bold).
     yy, xx = np.where(mask_crop)
     ax.scatter(xx + di, yy + dj, s=2, c="0.5", alpha=0.5,
                label="front pixels")
     _plot(axis_path_cropped, color="red", lw=2.0, label="main axis")
     for k, p in enumerate(side_a):
-        _plot(p, color="dodgerblue", lw=0.8, alpha=0.8,
-              label="offset +n" if k == 0 else None)
+        _plot_offset(p, color="dodgerblue", lw=0.8, alpha=0.8,
+                     label="offset +n" if k == 0 else None)
     for k, p in enumerate(side_b):
-        _plot(p, color="orange", lw=0.8, alpha=0.8,
-              label="offset -n" if k == 0 else None)
+        _plot_offset(p, color="orange", lw=0.8, alpha=0.8,
+                     label="offset -n" if k == 0 else None)
     _plot(perp_path_cropped, color="lime", lw=2.0, label="perpendicular")
     if mark_jicropped is not None:
         ax.scatter([mark_jicropped[1] + di], [mark_jicropped[0] + dj],
@@ -450,14 +481,45 @@ def main(argv=None) -> None:
     log.info("Isopycnal levels (kg m^-3): %s",
              ", ".join(f"{lv:.3f}" for lv in levels))
 
+    # Transect crossing-count per column (used for the auto-pick filter and
+    # the optional candidate listing).
+    crossings = curtains.transect_front_crossings(
+        axis_path, metrics["normals"], front_mask_cropped, args.perp_half_width,
+    )
+
+    if args.list_perp_candidates:
+        log.info("Perpendicular-point candidates (column: i,j  km  crossings):")
+        dist_km = metrics["dist_km"]
+        for c in range(axis_path.shape[0]):
+            km = "" if dist_km is None else f"{dist_km[c]:7.2f} km"
+            log.info("  col %4d: i=%4d j=%4d  %s  crossings=%d",
+                     c, int(axis_path[c, 1]) + i_slice.start,
+                     int(axis_path[c, 0]) + j_slice.start, km, crossings[c])
+
     # Perpendicular point: user index or the field extremum along the axis.
     axis_color = curtains.sample_curtain(color_display, axis_path)
     if args.perp_point is not None:
         perp_idx = int(np.clip(args.perp_point, 0, axis_path.shape[0] - 1))
+        log.info("Perpendicular point: axis column %d (user --perp-point); "
+                 "transect crosses front %d time(s)",
+                 perp_idx, crossings[perp_idx])
     else:
-        perp_idx = curtains.pick_extremum_index(axis_color, mode=args.extremum)
-    log.info("Perpendicular point: axis column %d (%s of %s)",
-             perp_idx, args.extremum, color_title)
+        search = axis_color.copy()
+        if not args.perp_allow_crossings:
+            # Exclude columns whose transect re-crosses the front (the squiggly
+            # hook); NaN their color so the extremum search ignores them.
+            bad = crossings > args.perp_max_crossings
+            search[:, bad] = np.nan
+            if not np.isfinite(search).any():
+                log.warning("No columns with <= %d crossings; falling back to "
+                            "the whole axis for the perpendicular point.",
+                            args.perp_max_crossings)
+                search = axis_color
+        perp_idx = curtains.pick_extremum_index(search, mode=args.extremum)
+        log.info("Perpendicular point: axis column %d (%s of %s, "
+                 "<= %d crossings); transect crosses front %d time(s)",
+                 perp_idx, args.extremum, color_title,
+                 args.perp_max_crossings, crossings[perp_idx])
 
     perp_path = curtains.perpendicular_path(
         axis_path, metrics["normals"], perp_idx, args.perp_half_width,
@@ -488,7 +550,7 @@ def main(argv=None) -> None:
         color_display, sigma0_clipped, Z_clipped, axis_path, metrics,
         args.n_offsets, out_off,
         levels=levels, clim=clim, cmap=cmap, color_title=color_title,
-        mark_index=perp_idx,
+        mark_index=perp_idx, trim=args.trim_offsets,
         title=f"Along-front curtains + offsets (front {label})",
     )
     log.info("Wrote %s", out_off)
@@ -513,7 +575,7 @@ def main(argv=None) -> None:
         plot_map_inset(
             surf, front_mask_full, axis_path, side_a, side_b, perp_path,
             (axis_path[perp_idx, 0], axis_path[perp_idx, 1]),
-            j_slice, i_slice, out_inset,
+            j_slice, i_slice, out_inset, trim=args.trim_offsets,
             title=(f"Front {label} curtain geometry "
                    f"(lon={float(XC_rect[j_pick, i_pick]):.2f}, "
                    f"lat={float(YC_rect[j_pick, i_pick]):.2f})"),

--- a/fronts/scripts/fronts_viz_curtain.py
+++ b/fronts/scripts/fronts_viz_curtain.py
@@ -5,23 +5,23 @@ This is the 2-D companion to ``fronts/scripts/fronts_viz_3d.py``.  It reuses
 that script's tile-loading / remapping / front-picking pipeline, then -- instead
 of a 3-D PyVista scene -- produces three static matplotlib curtain figures:
 
-1. **Main-axis curtain** (``{prefix}_{field}_mainaxis.png``) -- a vertical
+1. **Main-axis curtain** (``{prefix}_{field}_{loc}_mainaxis.png``) -- a vertical
    cross-section along the front's main axis (longest end-to-end path through
    the skeleton, side branches dropped).  x = distance along the front,
    y = depth, color = a configurable field (default ``Ri``), with isopycnal
    (sigma0) contours overlaid.
-2. **Along-front curtains with offsets** (``{prefix}_{field}_offsets_n{N}.png``)
+2. **Along-front curtains with offsets** (``{prefix}_{field}_{loc}_offsets_n{N}.png``)
    -- two columns (the two sides of the front); row 0 of each is the main
    axis, rows below are offsets 1..N pixels away.  Offset columns whose
    geometry self-overlaps (concave bends / skeleton noise) are trimmed.
-3. **Cross-front curtain** (``{prefix}_{field}_perp.png``) -- a perpendicular
-   transect cut at a chosen point along the main axis (default: the field
-   extremum over the full depth range), same curtain style.
+3. **Cross-front curtain** (``{prefix}_{field}_{loc}_perp.png``) -- a
+   perpendicular transect cut at a chosen point along the main axis (default:
+   the field extremum over the full depth range), same curtain style.
 
-A 2-D **map-view inset** (``{prefix}_{field}_inset.png``) shows the bbox with
-the main axis, the offset envelope, and the marked perpendicular point.  The
-``{field}`` token is the tile variable name (e.g. ``Ri``); ``{N}`` is
-``--n-offsets``.
+A 2-D **map-view inset** (``{prefix}_{field}_{loc}_inset.png``) shows the bbox
+with the main axis, the offset envelope, and the marked perpendicular point.
+``{field}`` is the tile variable name (e.g. ``Ri``), ``{loc}`` is the picked
+front's location (e.g. ``lat36.38_lon-124.20``), and ``{N}`` is ``--n-offsets``.
 
 Inputs mirror ``fronts_viz_3d``:
   * a 3-D **density tile** NetCDF (``sigma0(k, j, i)``, face-local) -- drives
@@ -131,13 +131,16 @@ def parse_args(argv=None) -> argparse.Namespace:
 
     # Locator -- exactly one pair.
     p.add_argument("--i", type=int, default=None,
-                   help="Rect-grid column (locator option A).")
+                   help="Rect-grid column (PREFERRED locator). Must land on a "
+                        "front pixel; errors on a 0 (no-front) pixel.")
     p.add_argument("--j", type=int, default=None,
-                   help="Rect-grid row (locator option A).")
+                   help="Rect-grid row (PREFERRED locator).")
     p.add_argument("--lat", type=float, default=None,
-                   help="Latitude in degrees (locator option B).")
+                   help="Latitude in degrees (advanced locator). Snaps to the "
+                        "nearest labelled front IN THIS TILE; guarded against "
+                        "out-of-tile values (the run logs the tile's bbox).")
     p.add_argument("--lon", type=float, default=None,
-                   help="Longitude in degrees (locator option B).")
+                   help="Longitude in degrees (advanced locator). See --lat.")
 
     # Geometry controls.
     p.add_argument("--margin", type=int, default=50,
@@ -204,9 +207,12 @@ def parse_args(argv=None) -> argparse.Namespace:
     # Output.
     p.add_argument("--output-prefix", type=Path, required=True,
                    help="Output path prefix; the script appends "
-                        "_{field}_mainaxis.png / _{field}_offsets_n{N}.png / "
-                        "_{field}_perp.png / _{field}_inset.png, where {field} "
-                        "is the tile variable name and {N} is --n-offsets.")
+                        "_{field}_{loc}_mainaxis.png / _..._offsets_n{N}.png / "
+                        "_..._perp.png / _..._inset.png, where {field} is the "
+                        "tile variable name, {loc} is the front's "
+                        "lat/lon (e.g. lat36.38_lon-124.20), and {N} is "
+                        "--n-offsets.  The lat/lon keeps different fronts from "
+                        "overwriting each other.")
     p.add_argument("--no-inset", action="store_true",
                    help="Skip the map-view inset figure.")
 
@@ -396,9 +402,10 @@ def main(argv=None) -> None:
 
     Side effects
     ------------
-    Writes ``{prefix}_{field}_mainaxis.png``,
-    ``{prefix}_{field}_offsets_n{N}.png``, ``{prefix}_{field}_perp.png`` and
-    (unless ``--no-inset``) ``{prefix}_{field}_inset.png``.
+    Writes ``{prefix}_{field}_{loc}_mainaxis.png``,
+    ``{prefix}_{field}_{loc}_offsets_n{N}.png``,
+    ``{prefix}_{field}_{loc}_perp.png`` and (unless ``--no-inset``)
+    ``{prefix}_{field}_{loc}_inset.png`` (``{loc}`` = ``lat{LAT}_lon{LON}``).
     """
     logging.basicConfig(
         level=logging.INFO,
@@ -456,6 +463,30 @@ def main(argv=None) -> None:
     YC_rect = remap_to_rect(YC_face, j_tile_lookup, i_tile_lookup)
     field_rect = remap_to_rect(field_face, j_tile_lookup, i_tile_lookup)
 
+    # ---------- Tile lat/lon bbox + lat/lon-locator guard ----------
+    # The tile is the full TILE_SIZE x TILE_SIZE chunk, not just the region
+    # around one front.  Log its lat/lon extent every run so the valid
+    # --lat/--lon range is always visible.
+    lat_min, lat_max = float(YC_rect.min()), float(YC_rect.max())
+    lon_min, lon_max = float(XC_rect.min()), float(XC_rect.max())
+    log.info("Tile lat/lon bbox: lat [%.3f, %.3f], lon [%.3f, %.3f]",
+             lat_min, lat_max, lon_min, lon_max)
+    if args.locator_kind == "latlon":
+        # --lat/--lon snaps to the nearest in-tile pixel via argmin, so an
+        # out-of-tile value would *silently* pick a corner front.  Hard-error
+        # (printing the bounds) instead.
+        pad = 0.05 * max(lat_max - lat_min, lon_max - lon_min)
+        if not (lat_min - pad <= args.lat <= lat_max + pad
+                and lon_min - pad <= args.lon <= lon_max + pad):
+            raise SystemExit(
+                f"--lat {args.lat} --lon {args.lon} is outside this tile's "
+                f"lat/lon bbox: lat [{lat_min:.3f}, {lat_max:.3f}], "
+                f"lon [{lon_min:.3f}, {lon_max:.3f}] (pad {pad:.3f} deg).  "
+                "The lat/lon locator snaps to the nearest in-tile pixel, so an "
+                "out-of-tile value would pick the wrong front.  Use --i/--j "
+                "(rect-grid indices) or a lat/lon inside the bbox above."
+            )
+
     # ---------- Pick the front ----------
     locator = ((args.i, args.j) if args.locator_kind == "ij"
                else (args.lat, args.lon))
@@ -463,9 +494,13 @@ def main(argv=None) -> None:
         labels_tile, args.locator_kind, locator,
         rect_i_start, rect_j_start, XC_rect, YC_rect,
     )
+    lon_pick = float(XC_rect[j_pick, i_pick])
+    lat_pick = float(YC_rect[j_pick, i_pick])
+    # Location tag baked into the output filenames so different fronts don't
+    # overwrite each other (e.g. "lat36.38_lon-124.20").
+    loc_tag = f"lat{lat_pick:.2f}_lon{lon_pick:.2f}"
     log.info("Selected front label=%d at tile-local (j=%d, i=%d) lon=%.3f lat=%.3f",
-             label, j_pick, i_pick,
-             float(XC_rect[j_pick, i_pick]), float(YC_rect[j_pick, i_pick]))
+             label, j_pick, i_pick, lon_pick, lat_pick)
 
     # ---------- Crop + depth clip ----------
     j_slice, i_slice = front_bbox_and_crop(labels_tile, label, margin=args.margin)
@@ -569,14 +604,14 @@ def main(argv=None) -> None:
     mld_curtain = mld_depth_2d[jj, ii]
 
     # ---------- Render the three figures ----------
-    # Filenames carry the field tag, and the offsets figure also carries the
-    # offset count: {prefix}_{field}_mainaxis.png, {prefix}_{field}_offsets_n{N}.png,
-    # {prefix}_{field}_perp.png.
+    # Filenames carry the field tag and the front's lat/lon (so different
+    # fronts don't overwrite); the offsets figure also carries the offset
+    # count.  e.g. {prefix}_Ri_lat36.38_lon-124.20_mainaxis.png
     prefix = args.output_prefix
-    out_main = prefix.with_name(f"{prefix.name}_{field_tag}_mainaxis.png")
-    out_off = prefix.with_name(
-        f"{prefix.name}_{field_tag}_offsets_n{args.n_offsets}.png")
-    out_perp = prefix.with_name(f"{prefix.name}_{field_tag}_perp.png")
+    stem = f"{prefix.name}_{field_tag}_{loc_tag}"
+    out_main = prefix.with_name(f"{stem}_mainaxis.png")
+    out_off = prefix.with_name(f"{stem}_offsets_n{args.n_offsets}.png")
+    out_perp = prefix.with_name(f"{stem}_perp.png")
 
     curtains.figure_main_axis(
         color_display, sigma0_clipped, Z_clipped, axis_path, metrics, out_main,
@@ -607,7 +642,7 @@ def main(argv=None) -> None:
 
     # ---------- Map-view inset ----------
     if not args.no_inset:
-        out_inset = prefix.with_name(f"{prefix.name}_{field_tag}_inset.png")
+        out_inset = prefix.with_name(f"{stem}_inset.png")
         side_a, side_b = curtains.offset_paths(
             axis_path, metrics["normals"], args.n_offsets,
         )

--- a/fronts/scripts/fronts_viz_curtain.py
+++ b/fronts/scripts/fronts_viz_curtain.py
@@ -541,7 +541,12 @@ def main(argv=None) -> None:
     if args.clim is not None:
         clim = tuple(args.clim)
     else:
-        clim = default_clim(color_display, field_style)
+        clim = default_clim(
+            color_display, field_style,
+            clip_override=(tuple(args.field_clip)
+                           if args.field_clip is not None else None),
+            transform_override=args.field_transform,
+        )
     cmap = args.cmap or field_style.cmap
     color_title = field_style.title or field_name
 

--- a/fronts/scripts/fronts_viz_curtain.py
+++ b/fronts/scripts/fronts_viz_curtain.py
@@ -1,0 +1,525 @@
+"""
+Render 2-D "curtain" cross-sections of a single labelled front through a tile.
+
+This is the 2-D companion to ``fronts/scripts/fronts_viz_3d.py``.  It reuses
+that script's tile-loading / remapping / front-picking pipeline, then -- instead
+of a 3-D PyVista scene -- produces three static matplotlib curtain figures:
+
+1. **Main-axis curtain** (``{prefix}_mainaxis.png``) -- a vertical
+   cross-section along the front's main axis (longest end-to-end path through
+   the skeleton, side branches dropped).  x = distance along the front,
+   y = depth, color = a configurable field (default ``Ri``), with isopycnal
+   (sigma0) contours overlaid.
+2. **Along-front curtains with offsets** (``{prefix}_offsets.png``) -- two
+   columns (the two sides of the front); row 0 of each is the main axis, rows
+   below are offsets 1..N pixels away.  Offset columns whose geometry
+   self-overlaps (concave bends / skeleton noise) are shaded.
+3. **Cross-front curtain** (``{prefix}_perp.png``) -- a perpendicular transect
+   cut at a chosen point along the main axis (default: the field extremum over
+   the full depth range), same curtain style.
+
+A 2-D **map-view inset** (``{prefix}_inset.png``) shows the bbox with the main
+axis, the offset envelope, and the marked perpendicular point.
+
+Inputs mirror ``fronts_viz_3d``:
+  * a 3-D **density tile** NetCDF (``sigma0(k, j, i)``, face-local) -- drives
+    isopycnal contours;
+  * a **field tile** (same window+timestamp, e.g. ``--property richardson``)
+    whose variable is the curtain color (REQUIRED here -- the curtain color and
+    the perpendicular-point extremum both need it; default ``Ri``);
+  * a global **labelled-fronts mask** on the rect grid;
+  * a locator: ``--i / --j`` or ``--lat / --lon``.
+
+CLI usage
+---------
+    python -m fronts.scripts.fronts_viz_curtain \\
+        --density-tile density_tile330_20121109T12.nc \\
+        --field-tile   Ri_tile330_20121109T12.nc \\
+        --labels       labeled_fronts_global_20121109T12_00_00_V4.npy \\
+        --i 13142 --j 9956 \\
+        --n-offsets 3 --perp-half-width 30 \\
+        --output-prefix /tmp/calcurrent_curtain
+"""
+
+# stdlib
+from __future__ import annotations
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+# numerical / plotting
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+# tile lookup + label loading helpers from the dev/mld utilities (same as 3-D).
+_DEV_MLD = Path(__file__).resolve().parents[2] / "dev" / "mld"
+if str(_DEV_MLD) not in sys.path:
+    sys.path.insert(0, str(_DEV_MLD))
+from density_utils import (  # noqa: E402
+    load_density_tile,
+    load_tile,
+    check_tiles_consistent,
+    load_labels_tile,
+    tile_scalar,
+    build_tile_lookup,
+    attach_lonlat_twins,
+)
+
+# Repo helpers.
+from fronts.llc.analysis import mixed_layer_depth_field  # noqa: E402
+from fronts.viz.fronts_3d import (  # noqa: E402
+    front_bbox_and_crop,
+    truncate_depth,
+)
+from fronts.viz.field_styles import (  # noqa: E402
+    get_style,
+    apply_transform,
+    default_clim,
+    NAN_COLOR,
+)
+from fronts.viz import curtains  # noqa: E402
+
+# Reuse the 3-D script's front-picking + remap helpers directly (no copy).
+from fronts.scripts.fronts_viz_3d import (  # noqa: E402
+    pick_front_label,
+    remap_to_rect,
+)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args(argv=None) -> argparse.Namespace:
+    """Build and parse the CLI arguments for ``fronts_viz_curtain.py``.
+
+    Parameters
+    ----------
+    argv : list of str or None
+        Argument list (default ``sys.argv[1:]``).
+
+    Returns
+    -------
+    argparse.Namespace
+        Parsed namespace; ``args.locator_kind`` is ``'ij'`` or ``'latlon'``.
+    """
+    p = argparse.ArgumentParser(
+        description="Render 2-D curtain cross-sections of one labelled front.",
+    )
+    p.add_argument("--density-tile", type=Path, required=True,
+                   help="NetCDF density tile (sigma0); drives isopycnals.")
+    p.add_argument("--field-tile", type=Path, required=True,
+                   help="NetCDF field tile (same window+timestamp) whose "
+                        "variable colors the curtains (e.g. a Ri tile).")
+    p.add_argument("--field-name", type=str, default=None,
+                   help="Variable name inside --field-tile "
+                        "(default: auto-detect the single 3-D variable).")
+    p.add_argument("--field-transform",
+                   choices=["log10", "symlog", "linear"], default=None,
+                   help="Override the field's registered display transform.")
+    p.add_argument("--field-clip", type=float, nargs=2, default=None,
+                   metavar=("LO", "HI"),
+                   help="Override the field's registered raw-value clip range.")
+    p.add_argument("--labels", type=Path, required=True,
+                   help="Global labelled-fronts mask (.npy or .nc).")
+
+    # Locator -- exactly one pair.
+    p.add_argument("--i", type=int, default=None,
+                   help="Rect-grid column (locator option A).")
+    p.add_argument("--j", type=int, default=None,
+                   help="Rect-grid row (locator option A).")
+    p.add_argument("--lat", type=float, default=None,
+                   help="Latitude in degrees (locator option B).")
+    p.add_argument("--lon", type=float, default=None,
+                   help="Longitude in degrees (locator option B).")
+
+    # Geometry controls.
+    p.add_argument("--margin", type=int, default=50,
+                   help="Pixel margin around the front bbox (default 50).")
+    p.add_argument("--n-below", type=int, default=3,
+                   help="LLC levels below the deepest MLD to include "
+                        "(default 3); sets the curtain depth extent.")
+    p.add_argument("--n-offsets", type=int, default=3,
+                   help="Number of offset rows per side (default 3).")
+    p.add_argument("--perp-half-width", type=int, default=30,
+                   help="Half-width (px) of the perpendicular transect "
+                        "(default 30; total length 2*N+1).")
+    p.add_argument("--perp-point", type=int, default=None,
+                   help="Main-axis column index for the perpendicular "
+                        "transect.  Default: the field-extremum column.")
+    p.add_argument("--extremum", choices=["min", "max"], default="min",
+                   help="Whether the default perpendicular point is the field "
+                        "minimum (default; e.g. lowest Ri) or maximum.")
+
+    # Smoothing of the direction field (NOT the main-axis columns).
+    p.add_argument("--smooth-normals", action="store_true",
+                   help="Smooth the tangent/normal direction field before "
+                        "throwing offsets + the perpendicular (off by "
+                        "default).  Does NOT move the main-axis columns.")
+    p.add_argument("--smooth-window", type=int, default=5,
+                   help="Odd pixel window for --smooth-normals (default 5).")
+
+    # Display.
+    p.add_argument("--isopycnals", type=float, nargs="+", default=None,
+                   help="Explicit sigma0 contour levels; otherwise auto-picked "
+                        "from the cross-front surface contrast.")
+    p.add_argument("--n-isopycnals", type=int, default=8,
+                   help="Number of auto-picked isopycnal levels (default 8).")
+    p.add_argument("--clim", type=float, nargs=2, default=None,
+                   metavar=("LO", "HI"),
+                   help="Color limits for the (transformed) color field; "
+                        "default: registered style clim, else 2/98 percentile.")
+    p.add_argument("--cmap", type=str, default=None,
+                   help="Colormap for the color field (default: the field's "
+                        "registered style cmap).")
+
+    # Output.
+    p.add_argument("--output-prefix", type=Path, required=True,
+                   help="Output path prefix; the script appends "
+                        "_mainaxis.png / _offsets.png / _perp.png / _inset.png.")
+    p.add_argument("--no-inset", action="store_true",
+                   help="Skip the map-view inset figure.")
+
+    args = p.parse_args(argv)
+
+    ij = (args.i is not None) and (args.j is not None)
+    ll = (args.lat is not None) and (args.lon is not None)
+    if ij == ll:
+        p.error("Supply exactly one of (--i AND --j) or (--lat AND --lon).")
+    args.locator_kind = "ij" if ij else "latlon"
+    return args
+
+
+# ---------------------------------------------------------------------------
+# Isopycnal level picking (depth-aware percentile over the whole curtain)
+# ---------------------------------------------------------------------------
+
+def pick_isopycnal_levels(
+    sigma0_clipped: np.ndarray,
+    user_levels,
+    n_levels: int,
+) -> np.ndarray:
+    """Choose sigma0 contour levels for the curtain isopycnals.
+
+    Unlike the 3-D ``pick_isopycnals_across_front`` (which brackets the
+    near-surface cross-front contrast), the curtain spans the full depth, so we
+    bracket the 2/98 percentile of the whole cropped+clipped volume -- this
+    yields contours that read across the entire depth-distance panel.
+
+    Parameters
+    ----------
+    sigma0_clipped : numpy.ndarray
+        ``(K, J, I)`` cropped + depth-clipped sigma0.
+    user_levels : sequence of float or None
+        Explicit levels; returned verbatim when supplied.
+    n_levels : int
+        Number of evenly spaced levels when auto-picking.
+
+    Returns
+    -------
+    numpy.ndarray
+        1-D array of sigma0 contour values.
+    """
+    if user_levels is not None:
+        return np.asarray(list(user_levels), dtype=np.float64)
+    lo = float(np.nanpercentile(sigma0_clipped, 2))
+    hi = float(np.nanpercentile(sigma0_clipped, 98))
+    return np.linspace(lo, hi, int(n_levels))
+
+
+# ---------------------------------------------------------------------------
+# Map-view inset
+# ---------------------------------------------------------------------------
+
+def plot_map_inset(
+    surface_field: np.ndarray,
+    front_mask_full: np.ndarray,
+    axis_path_cropped: np.ndarray,
+    side_a, side_b,
+    perp_path_cropped: np.ndarray,
+    mark_jicropped,
+    j_slice: slice,
+    i_slice: slice,
+    output_path: Path,
+    *,
+    title: str = "",
+) -> Path:
+    """Plan-view map of the bbox: surface field + axis + offsets + perp point.
+
+    Parameters
+    ----------
+    surface_field : numpy.ndarray
+        2-D near-surface display field (rect-tile-local frame, full tile).
+    front_mask_full : numpy.ndarray
+        Full-tile boolean mask of the selected front.
+    axis_path_cropped : numpy.ndarray
+        ``(L, 2)`` main axis in the *cropped* frame.
+    side_a, side_b : list of numpy.ndarray
+        Offset polylines in the cropped frame.
+    perp_path_cropped : numpy.ndarray
+        Perpendicular transect in the cropped frame.
+    mark_jicropped : tuple
+        ``(j, i)`` of the marked perpendicular point in the cropped frame.
+    j_slice, i_slice : slice
+        Crop slices (to shift cropped coords back to tile-local for plotting).
+    output_path : pathlib.Path
+        PNG output.
+    title : str, optional
+        Figure title.
+
+    Returns
+    -------
+    pathlib.Path
+        The output path.
+    """
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    surf_crop = surface_field[j_slice, i_slice]
+    mask_crop = front_mask_full[j_slice, i_slice]
+    extent = (i_slice.start, i_slice.stop, j_slice.start, j_slice.stop)
+
+    fig, ax = plt.subplots(figsize=(9, 8))
+    if np.isfinite(surf_crop).any():
+        vlo = float(np.nanpercentile(surf_crop, 2))
+        vhi = float(np.nanpercentile(surf_crop, 98))
+    else:
+        vlo, vhi = 0.0, 1.0
+    ax.imshow(surf_crop, origin="lower", extent=extent, cmap="Greys",
+              vmin=vlo, vmax=vhi, interpolation="nearest", aspect="equal")
+
+    di, dj = i_slice.start, j_slice.start
+
+    def _plot(p, **kw):
+        ax.plot(p[:, 1] + di, p[:, 0] + dj, **kw)
+
+    # All front pixels (faint), then the main axis (bold).
+    yy, xx = np.where(mask_crop)
+    ax.scatter(xx + di, yy + dj, s=2, c="0.5", alpha=0.5,
+               label="front pixels")
+    _plot(axis_path_cropped, color="red", lw=2.0, label="main axis")
+    for k, p in enumerate(side_a):
+        _plot(p, color="dodgerblue", lw=0.8, alpha=0.8,
+              label="offset +n" if k == 0 else None)
+    for k, p in enumerate(side_b):
+        _plot(p, color="orange", lw=0.8, alpha=0.8,
+              label="offset -n" if k == 0 else None)
+    _plot(perp_path_cropped, color="lime", lw=2.0, label="perpendicular")
+    if mark_jicropped is not None:
+        ax.scatter([mark_jicropped[1] + di], [mark_jicropped[0] + dj],
+                   s=80, marker="*", c="lime", edgecolors="k", zorder=5,
+                   label="perp point")
+
+    ax.set_xlabel("i (rect tile-local)")
+    ax.set_ylabel("j (rect tile-local)")
+    ax.set_title(title or "Curtain geometry (plan view)")
+    ax.legend(loc="upper right", fontsize=8, framealpha=0.9)
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    return output_path
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main(argv=None) -> None:
+    """CLI entry point.
+
+    Parameters
+    ----------
+    argv : list of str or None
+        Argument list (default ``sys.argv[1:]``).
+
+    Side effects
+    ------------
+    Writes ``{prefix}_mainaxis.png``, ``{prefix}_offsets.png``,
+    ``{prefix}_perp.png`` and (unless ``--no-inset``) ``{prefix}_inset.png``.
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(message)s",
+        stream=sys.stdout,
+    )
+    args = parse_args(argv)
+    log = logging.getLogger("fronts_viz_curtain")
+
+    # ---------- Load density + field tiles ----------
+    log.info("Loading density tile %s", args.density_tile)
+    ds = load_density_tile(args.density_tile)
+    rect_i_start = int(tile_scalar(ds, "rect_i_start"))
+    rect_j_start = int(tile_scalar(ds, "rect_j_start"))
+    face_index = int(tile_scalar(ds, "face_index"))
+
+    sigma0_face = ds["sigma0"].values  # (K, J_face, I_face)
+    Z = ds["Z"].values.astype(np.float64)  # (K,), negative downward
+    XC_face = ds["XC"].values
+    YC_face = ds["YC"].values
+
+    log.info("Loading field tile %s", args.field_tile)
+    ds_field = load_tile(args.field_tile, var_name=args.field_name)
+    check_tiles_consistent(ds, ds_field, "--density-tile", "--field-tile")
+    field_name = ds_field.attrs["tile_var_name"]
+    field_face = ds_field[field_name].values
+    if field_face.shape != sigma0_face.shape:
+        raise SystemExit(
+            f"--field-tile variable '{field_name}' has shape "
+            f"{field_face.shape}, expected {sigma0_face.shape}."
+        )
+    field_style = get_style(field_name)
+    log.info("Coloring curtains by %s (transform=%s)",
+             field_name, args.field_transform or field_style.transform)
+
+    # ---------- Frame remap ----------
+    log.info("Building tile lookup + remapping to rect-tile-local frame")
+    j_tile_lookup, i_tile_lookup = build_tile_lookup(
+        rect_i_start, rect_j_start, face_index,
+    )
+    rect_j_slice = slice(rect_j_start, rect_j_start + j_tile_lookup.shape[0])
+    rect_i_slice = slice(rect_i_start, rect_i_start + j_tile_lookup.shape[1])
+    labels_tile = load_labels_tile(args.labels, rect_j_slice, rect_i_slice)
+
+    sigma0_rect = remap_to_rect(sigma0_face, j_tile_lookup, i_tile_lookup)
+    XC_rect = remap_to_rect(XC_face, j_tile_lookup, i_tile_lookup)
+    YC_rect = remap_to_rect(YC_face, j_tile_lookup, i_tile_lookup)
+    field_rect = remap_to_rect(field_face, j_tile_lookup, i_tile_lookup)
+
+    # ---------- Pick the front ----------
+    locator = ((args.i, args.j) if args.locator_kind == "ij"
+               else (args.lat, args.lon))
+    label, j_pick, i_pick = pick_front_label(
+        labels_tile, args.locator_kind, locator,
+        rect_i_start, rect_j_start, XC_rect, YC_rect,
+    )
+    log.info("Selected front label=%d at tile-local (j=%d, i=%d) lon=%.3f lat=%.3f",
+             label, j_pick, i_pick,
+             float(XC_rect[j_pick, i_pick]), float(YC_rect[j_pick, i_pick]))
+
+    # ---------- Crop + depth clip ----------
+    j_slice, i_slice = front_bbox_and_crop(labels_tile, label, margin=args.margin)
+    sigma0_cropped = sigma0_rect[:, j_slice, i_slice]
+    field_cropped = field_rect[:, j_slice, i_slice]
+    front_mask_full = (labels_tile == label)
+    front_mask_cropped = front_mask_full[j_slice, i_slice]
+
+    z_mld, k_mld = mixed_layer_depth_field(sigma0_cropped, Z)
+    sigma0_clipped, Z_clipped, k_clip = truncate_depth(
+        sigma0_cropped, Z, k_mld, n_below=args.n_below,
+    )
+    field_clipped = field_cropped[:k_clip]
+    log.info("Curtain depth extent: k=%d levels, z=[%.1f, %.1f] m",
+             k_clip, float(Z_clipped[0]), float(Z_clipped[-1]))
+
+    # Transform the color field into display space (e.g. log10 Ri).
+    color_display = apply_transform(
+        field_clipped, field_style,
+        clip_override=(tuple(args.field_clip)
+                       if args.field_clip is not None else None),
+        transform_override=args.field_transform,
+    )
+
+    # ---------- Geometry: main axis, metrics, offsets, perpendicular ----------
+    axis_path = curtains.extract_main_axis(front_mask_cropped)  # cropped frame
+    log.info("Main axis: %d pixels", axis_path.shape[0])
+
+    # path_metrics wants lon/lat in the cropped frame for km distances.
+    XC_crop = XC_rect[j_slice, i_slice]
+    YC_crop = YC_rect[j_slice, i_slice]
+    metrics = curtains.path_metrics(
+        axis_path, XC_crop, YC_crop,
+        smooth=args.smooth_normals, smooth_window=args.smooth_window,
+    )
+
+    # Color limits + colormap from the field style unless overridden.
+    if args.clim is not None:
+        clim = tuple(args.clim)
+    else:
+        clim = default_clim(color_display, field_style)
+    cmap = args.cmap or field_style.cmap
+    color_title = field_style.title or field_name
+
+    # Isopycnal levels span the full curtain depth.
+    levels = pick_isopycnal_levels(
+        sigma0_clipped, args.isopycnals, args.n_isopycnals,
+    )
+    log.info("Isopycnal levels (kg m^-3): %s",
+             ", ".join(f"{lv:.3f}" for lv in levels))
+
+    # Perpendicular point: user index or the field extremum along the axis.
+    axis_color = curtains.sample_curtain(color_display, axis_path)
+    if args.perp_point is not None:
+        perp_idx = int(np.clip(args.perp_point, 0, axis_path.shape[0] - 1))
+    else:
+        perp_idx = curtains.pick_extremum_index(axis_color, mode=args.extremum)
+    log.info("Perpendicular point: axis column %d (%s of %s)",
+             perp_idx, args.extremum, color_title)
+
+    perp_path = curtains.perpendicular_path(
+        axis_path, metrics["normals"], perp_idx, args.perp_half_width,
+    )
+
+    # MLD sampled along the axis (depths, negative metres) for the overlay.
+    # k_mld is (J', I'); convert to depth then sample along the axis pixels.
+    mld_depth_2d = np.where(k_mld >= 0, z_mld, np.nan)
+    jj = np.clip(np.round(axis_path[:, 0]).astype(int), 0, mld_depth_2d.shape[0] - 1)
+    ii = np.clip(np.round(axis_path[:, 1]).astype(int), 0, mld_depth_2d.shape[1] - 1)
+    mld_curtain = mld_depth_2d[jj, ii]
+
+    # ---------- Render the three figures ----------
+    prefix = args.output_prefix
+    out_main = prefix.with_name(prefix.name + "_mainaxis.png")
+    out_off = prefix.with_name(prefix.name + "_offsets.png")
+    out_perp = prefix.with_name(prefix.name + "_perp.png")
+
+    curtains.figure_main_axis(
+        color_display, sigma0_clipped, Z_clipped, axis_path, metrics, out_main,
+        levels=levels, clim=clim, cmap=cmap, color_title=color_title,
+        mld_curtain=mld_curtain, mark_index=perp_idx,
+        title=f"Main-axis curtain (front {label})",
+    )
+    log.info("Wrote %s", out_main)
+
+    curtains.figure_offsets(
+        color_display, sigma0_clipped, Z_clipped, axis_path, metrics,
+        args.n_offsets, out_off,
+        levels=levels, clim=clim, cmap=cmap, color_title=color_title,
+        mark_index=perp_idx,
+        title=f"Along-front curtains + offsets (front {label})",
+    )
+    log.info("Wrote %s", out_off)
+
+    curtains.figure_perpendicular(
+        color_display, sigma0_clipped, Z_clipped, perp_path,
+        args.perp_half_width, out_perp,
+        XC_rect=XC_crop, YC_rect=YC_crop,
+        levels=levels, clim=clim, cmap=cmap, color_title=color_title,
+        title=f"Cross-front curtain at axis col {perp_idx} (front {label})",
+    )
+    log.info("Wrote %s", out_perp)
+
+    # ---------- Map-view inset ----------
+    if not args.no_inset:
+        out_inset = prefix.with_name(prefix.name + "_inset.png")
+        side_a, side_b = curtains.offset_paths(
+            axis_path, metrics["normals"], args.n_offsets,
+        )
+        k_ref = int(np.abs(np.abs(Z) - 10.0).argmin())
+        surf = sigma0_rect[k_ref]
+        plot_map_inset(
+            surf, front_mask_full, axis_path, side_a, side_b, perp_path,
+            (axis_path[perp_idx, 0], axis_path[perp_idx, 1]),
+            j_slice, i_slice, out_inset,
+            title=(f"Front {label} curtain geometry "
+                   f"(lon={float(XC_rect[j_pick, i_pick]):.2f}, "
+                   f"lat={float(YC_rect[j_pick, i_pick]):.2f})"),
+        )
+        log.info("Wrote %s", out_inset)
+
+
+if __name__ == "__main__":
+    main()

--- a/fronts/scripts/fronts_viz_curtain.py
+++ b/fronts/scripts/fronts_viz_curtain.py
@@ -272,15 +272,31 @@ def plot_map_inset(
     i_slice: slice,
     output_path: Path,
     *,
+    cmap: str = "viridis",
+    clim: tuple[float, float] | None = None,
+    color_title: str = "",
+    nan_color: str = "#9e9e9e",
     trim: bool = True,
     title: str = "",
 ) -> Path:
     """Plan-view map of the bbox: surface field + axis + offsets + perp point.
 
+    The background is the near-surface slice of the **color field** (e.g. Ri),
+    in the same display space / colormap as the curtains, with a colorbar.
+
     Parameters
     ----------
     surface_field : numpy.ndarray
-        2-D near-surface display field (rect-tile-local frame, full tile).
+        2-D near-surface display-space color field (rect-tile-local frame,
+        full tile) -- e.g. ``apply_transform(field_rect[k_ref], style)``.
+    cmap : str, optional
+        Colormap for the field background (default the field-style cmap).
+    clim : tuple of (float, float), optional
+        Color limits for the field; default 2/98 percentile of the bbox crop.
+    color_title : str, optional
+        Colorbar label (the field's display title).
+    nan_color : str, optional
+        Color for NaN cells (land / clipped / undefined); default neutral gray.
     front_mask_full : numpy.ndarray
         Full-tile boolean mask of the selected front.
     axis_path_cropped : numpy.ndarray
@@ -311,13 +327,20 @@ def plot_map_inset(
     extent = (i_slice.start, i_slice.stop, j_slice.start, j_slice.stop)
 
     fig, ax = plt.subplots(figsize=(9, 8))
-    if np.isfinite(surf_crop).any():
+    if clim is not None:
+        vlo, vhi = clim
+    elif np.isfinite(surf_crop).any():
         vlo = float(np.nanpercentile(surf_crop, 2))
         vhi = float(np.nanpercentile(surf_crop, 98))
     else:
         vlo, vhi = 0.0, 1.0
-    ax.imshow(surf_crop, origin="lower", extent=extent, cmap="Greys",
-              vmin=vlo, vmax=vhi, interpolation="nearest", aspect="equal")
+    cmap_obj = plt.get_cmap(cmap).copy()
+    cmap_obj.set_bad(nan_color)
+    im = ax.imshow(np.ma.masked_invalid(surf_crop), origin="lower",
+                   extent=extent, cmap=cmap_obj, vmin=vlo, vmax=vhi,
+                   interpolation="nearest", aspect="equal")
+    cbar = fig.colorbar(im, ax=ax, shrink=0.85, pad=0.02)
+    cbar.set_label(color_title)
 
     di, dj = i_slice.start, j_slice.start
 
@@ -334,7 +357,7 @@ def plot_map_inset(
 
     # All front pixels (faint), then the main axis (bold).
     yy, xx = np.where(mask_crop)
-    ax.scatter(xx + di, yy + dj, s=2, c="0.5", alpha=0.5,
+    ax.scatter(xx + di, yy + dj, s=2, c="k", alpha=0.35,
                label="front pixels")
     _plot(axis_path_cropped, color="red", lw=2.0, label="main axis")
     for k, p in enumerate(side_a):
@@ -588,12 +611,21 @@ def main(argv=None) -> None:
         side_a, side_b = curtains.offset_paths(
             axis_path, metrics["normals"], args.n_offsets,
         )
+        # Background = near-surface slice of the COLOR FIELD (display space),
+        # same colormap/clim as the curtains.
         k_ref = int(np.abs(np.abs(Z) - 10.0).argmin())
-        surf = sigma0_rect[k_ref]
+        field_surf = apply_transform(
+            field_rect[k_ref], field_style,
+            clip_override=(tuple(args.field_clip)
+                           if args.field_clip is not None else None),
+            transform_override=args.field_transform,
+        )
         plot_map_inset(
-            surf, front_mask_full, axis_path, side_a, side_b, perp_path,
+            field_surf, front_mask_full, axis_path, side_a, side_b, perp_path,
             (axis_path[perp_idx, 0], axis_path[perp_idx, 1]),
-            j_slice, i_slice, out_inset, trim=args.trim_offsets,
+            j_slice, i_slice, out_inset,
+            cmap=cmap, clim=clim, color_title=color_title, nan_color=NAN_COLOR,
+            trim=args.trim_offsets,
             title=(f"Front {label} curtain geometry "
                    f"(lon={float(XC_rect[j_pick, i_pick]):.2f}, "
                    f"lat={float(YC_rect[j_pick, i_pick]):.2f})"),

--- a/fronts/tests/test_curtains.py
+++ b/fronts/tests/test_curtains.py
@@ -1,0 +1,209 @@
+"""Unit tests for fronts/viz/curtains.py (geometry + sampling)."""
+
+import numpy as np
+import pytest
+
+from fronts.viz import curtains
+
+
+# ---------------------------------------------------------------------------
+# Skeleton fixtures (thinned, 1-px wide)
+# ---------------------------------------------------------------------------
+
+def _straight_horizontal(H=20, W=40, j=10, i0=5, i1=34):
+    m = np.zeros((H, W), dtype=bool)
+    m[j, i0:i1 + 1] = True
+    return m
+
+
+def _with_side_branch():
+    # A long horizontal spine with a short vertical stub branching off.
+    m = _straight_horizontal()
+    # stub from the spine at i=20 going up 4 pixels
+    for d in range(1, 5):
+        m[10 - d, 20] = True
+    return m
+
+
+def _curved():
+    # A quarter-circle-ish arc traced pixel by pixel.
+    H = W = 60
+    m = np.zeros((H, W), dtype=bool)
+    t = np.linspace(0, np.pi / 2, 80)
+    j = (10 + 40 * np.sin(t)).round().astype(int)
+    i = (10 + 40 * np.cos(t)).round().astype(int)
+    m[j, i] = True
+    return m
+
+
+# ---------------------------------------------------------------------------
+# extract_main_axis
+# ---------------------------------------------------------------------------
+
+def test_main_axis_straight():
+    m = _straight_horizontal()
+    axis = curtains.extract_main_axis(m)
+    # Should recover all 30 spine pixels (5..34 inclusive).
+    assert axis.shape[0] == 30
+    # All on row 10.
+    assert np.all(axis[:, 0] == 10)
+    # Monotonic in i (ordered along the line).
+    di = np.diff(axis[:, 1])
+    assert np.all(np.abs(di) == 1)
+
+
+def test_main_axis_ignores_side_branch():
+    m = _with_side_branch()
+    axis = curtains.extract_main_axis(m)
+    # The main axis is the 30-px spine; the 4-px stub must be excluded.
+    assert axis.shape[0] == 30
+    assert np.all(axis[:, 0] == 10)  # no stub pixels (which are at j<10)
+
+
+def test_main_axis_curved_endpoints():
+    m = _curved()
+    axis = curtains.extract_main_axis(m)
+    # Endpoints of the arc should be the two extremes.
+    pts = set(map(tuple, np.argwhere(m)))
+    assert tuple(axis[0]) in pts and tuple(axis[-1]) in pts
+    # Path length should cover most of the arc pixels.
+    assert axis.shape[0] >= 0.8 * len(pts)
+
+
+def test_main_axis_single_pixel():
+    m = np.zeros((10, 10), dtype=bool)
+    m[5, 5] = True
+    axis = curtains.extract_main_axis(m)
+    assert axis.shape[0] == 1
+    assert tuple(axis[0]) == (5, 5)
+
+
+def test_main_axis_empty_raises():
+    with pytest.raises(ValueError):
+        curtains.extract_main_axis(np.zeros((5, 5), dtype=bool))
+
+
+# ---------------------------------------------------------------------------
+# path_metrics: distances + normals, smoothing only affects direction
+# ---------------------------------------------------------------------------
+
+def test_path_metrics_straight_normals():
+    m = _straight_horizontal()
+    axis = curtains.extract_main_axis(m)
+    met = curtains.path_metrics(axis)
+    # Tangent of a horizontal line is +/- i-direction; normal is +/- j.
+    assert np.allclose(np.abs(met["tangents"][:, 0]), 0, atol=1e-9)
+    assert np.allclose(np.abs(met["normals"][:, 1]), 0, atol=1e-9)
+    # dist_px increments by 1 per pixel.
+    assert np.allclose(np.diff(met["dist_px"]), 1.0)
+
+
+def test_path_metrics_smoothing_keeps_columns():
+    m = _curved()
+    axis = curtains.extract_main_axis(m)
+    raw = curtains.path_metrics(axis, smooth=False)
+    sm = curtains.path_metrics(axis, smooth=True, smooth_window=5)
+    # Distances (column positions) are identical -- smoothing never moves them.
+    assert np.allclose(raw["dist_px"], sm["dist_px"])
+    # Normals differ (direction field was smoothed).
+    assert not np.allclose(raw["normals"], sm["normals"])
+    # Smoothed normals are less jittery: smaller mean angular step.
+    def _ang_step(n):
+        ang = np.arctan2(n[:, 0], n[:, 1])
+        return np.mean(np.abs(np.diff(np.unwrap(ang))))
+    assert _ang_step(sm["normals"]) <= _ang_step(raw["normals"]) + 1e-9
+
+
+def test_path_metrics_km_monotonic():
+    m = _straight_horizontal()
+    axis = curtains.extract_main_axis(m)
+    # Fake lon/lat: 0.01 deg per pixel in i.
+    H, W = m.shape
+    XC = np.tile(np.arange(W) * 0.01, (H, 1))
+    YC = np.full((H, W), 30.0)
+    met = curtains.path_metrics(axis, XC, YC)
+    assert met["dist_km"] is not None
+    assert np.all(np.diff(met["dist_km"]) > 0)
+    # ~0.01 deg lon at 30N ~ 0.96 km; 29 steps -> ~28 km total, sane range.
+    assert 20 < met["dist_km"][-1] < 35
+
+
+# ---------------------------------------------------------------------------
+# offsets + overlap detection
+# ---------------------------------------------------------------------------
+
+def test_offset_paths_shapes_and_sides():
+    m = _straight_horizontal()
+    axis = curtains.extract_main_axis(m)
+    met = curtains.path_metrics(axis)
+    a, b = curtains.offset_paths(axis, met["normals"], 3)
+    assert len(a) == 3 and len(b) == 3
+    # Side A and B are mirror images about the axis.
+    for k in range(3):
+        assert np.allclose(a[k] + b[k], 2 * axis, atol=1e-9)
+    # Offset 1 of a horizontal line is shifted by 1 px in j.
+    assert np.allclose(np.abs(a[0][:, 0] - axis[:, 0]), 1.0)
+
+
+def test_offset_quality_straight_no_overlap():
+    m = _straight_horizontal()
+    axis = curtains.extract_main_axis(m)
+    met = curtains.path_metrics(axis)
+    a, _ = curtains.offset_paths(axis, met["normals"], 3)
+    # A straight line's offsets never self-overlap.
+    for p in a:
+        assert not curtains.offset_quality_flags(p).any()
+
+
+def test_offset_quality_flags_tight_curve():
+    # Tight curve -> inner offsets collide; expect some flagged columns.
+    m = _curved()
+    axis = curtains.extract_main_axis(m)
+    met = curtains.path_metrics(axis, smooth=False)
+    a, b = curtains.offset_paths(axis, met["normals"], 8)
+    # The concave side should show overlaps at the largest offset.
+    flagged_any = any(curtains.offset_quality_flags(p).any() for p in (a + b))
+    assert flagged_any
+
+
+# ---------------------------------------------------------------------------
+# sample_curtain + perpendicular + extremum
+# ---------------------------------------------------------------------------
+
+def test_sample_curtain_constant_and_nan():
+    K, H, W = 5, 20, 40
+    field = np.full((K, H, W), 3.0)
+    m = _straight_horizontal(H, W)
+    axis = curtains.extract_main_axis(m)
+    cur = curtains.sample_curtain(field, axis)
+    assert cur.shape == (K, axis.shape[0])
+    assert np.allclose(cur, 3.0)
+    # A path leaving the window -> NaN.
+    off = axis.astype(float).copy()
+    off[:, 0] = -5  # above the grid
+    cur2 = curtains.sample_curtain(field, off)
+    assert np.all(np.isnan(cur2))
+
+
+def test_perpendicular_path_geometry():
+    m = _straight_horizontal()
+    axis = curtains.extract_main_axis(m)
+    met = curtains.path_metrics(axis)
+    idx = axis.shape[0] // 2
+    perp = curtains.perpendicular_path(axis, met["normals"], idx, 5)
+    assert perp.shape == (11, 2)
+    # Centre row equals the axis point.
+    assert np.allclose(perp[5], axis[idx])
+    # For a horizontal axis, the perpendicular runs in j (column i constant).
+    assert np.allclose(perp[:, 1], axis[idx, 1], atol=1e-9)
+
+
+def test_pick_extremum_index():
+    K, L = 4, 12
+    cur = np.full((K, L), 1.0)
+    cur[2, 7] = -3.0  # a deep minimum at column 7
+    cur[1, 3] = 9.0   # a maximum at column 3
+    assert curtains.pick_extremum_index(cur, "min") == 7
+    assert curtains.pick_extremum_index(cur, "max") == 3
+    with pytest.raises(ValueError):
+        curtains.pick_extremum_index(np.full((K, L), np.nan), "min")

--- a/fronts/tests/test_curtains.py
+++ b/fronts/tests/test_curtains.py
@@ -1,9 +1,12 @@
-"""Unit tests for fronts/viz/curtains.py (geometry + sampling)."""
+"""Unit tests for fronts/viz/curtains.py (geometry + sampling) and
+fronts/viz/field_styles.py (transforms + color limits), plus smoke tests
+for the figure assemblers."""
 
 import numpy as np
 import pytest
 
 from fronts.viz import curtains
+from fronts.viz.field_styles import FieldStyle, apply_transform, default_clim
 
 
 # ---------------------------------------------------------------------------
@@ -260,3 +263,152 @@ def test_pick_extremum_index():
     assert curtains.pick_extremum_index(cur, "max") == 3
     with pytest.raises(ValueError):
         curtains.pick_extremum_index(np.full((K, L), np.nan), "min")
+
+
+# ---------------------------------------------------------------------------
+# field_styles.apply_transform
+# ---------------------------------------------------------------------------
+
+def test_apply_transform_log10_nonpositive_to_nan():
+    style = FieldStyle(transform="log10")
+    vals = np.array([-1.0, 0.0, 1.0, 100.0, np.nan, np.inf])
+    out = apply_transform(vals, style)
+    assert np.isnan(out[0])          # negative -> NaN
+    assert np.isnan(out[1])          # zero -> NaN
+    assert np.isnan(out[4]) and np.isnan(out[5])  # non-finite -> NaN
+    assert out[2] == pytest.approx(0.0)   # log10(1)
+    assert out[3] == pytest.approx(2.0)   # log10(100)
+
+
+def test_apply_transform_log10_clips_before_log():
+    style = FieldStyle(transform="log10", clip=(1e-2, 1e2))
+    out = apply_transform(np.array([1e-6, 1e6]), style)
+    assert out[0] == pytest.approx(-2.0)  # clipped up to 1e-2
+    assert out[1] == pytest.approx(2.0)   # clipped down to 1e2
+
+
+def test_apply_transform_symlog_signed():
+    style = FieldStyle(transform="symlog", linthresh=1.0)
+    vals = np.array([-99.0, 0.0, 99.0])
+    out = apply_transform(vals, style)
+    # sign(x) * log10(1 + |x| / linthresh)
+    assert out[1] == pytest.approx(0.0)
+    assert out[2] == pytest.approx(2.0)       # log10(1 + 99)
+    assert out[0] == pytest.approx(-out[2])   # odd function
+
+
+def test_apply_transform_linear_clip_and_scale():
+    style = FieldStyle(transform="linear", clip=(-2.0, 2.0), scale=1e-1)
+    out = apply_transform(np.array([-5.0, 0.1, 5.0]), style)
+    assert out[0] == pytest.approx(-20.0)  # clip to -2, then / 0.1
+    assert out[1] == pytest.approx(1.0)
+    assert out[2] == pytest.approx(20.0)
+
+
+def test_apply_transform_overrides():
+    style = FieldStyle(transform="log10", clip=(1e-2, 1e4))
+    vals = np.array([-10.0, 10.0])
+    # Override to symlog: negative values survive instead of going NaN.
+    out = apply_transform(vals, style, transform_override="symlog",
+                          clip_override=(-5.0, 5.0))
+    assert np.isfinite(out).all()
+    assert out[0] == pytest.approx(-out[1])  # clipped to +/-5, symmetric
+
+
+def test_apply_transform_unknown_raises():
+    with pytest.raises(ValueError):
+        apply_transform(np.array([1.0]), FieldStyle(transform="sqrt"))
+
+
+# ---------------------------------------------------------------------------
+# field_styles.default_clim (pinned clim vs center-symmetric vs percentiles)
+# ---------------------------------------------------------------------------
+
+def test_default_clim_pinned():
+    style = FieldStyle(clim=(-1.0, 2.0))
+    assert default_clim(np.linspace(-9, 9, 100), style) == (-1.0, 2.0)
+
+
+def test_default_clim_pinned_skipped_on_override():
+    # A pinned clim is calibrated to the style's own display space, so a CLI
+    # transform/clip override must fall back to percentiles.
+    style = FieldStyle(clim=(-1.0, 2.0))
+    vals = np.linspace(-9, 9, 1000)
+    lo, hi = default_clim(vals, style, transform_override="symlog")
+    assert (lo, hi) != (-1.0, 2.0)
+    assert lo == pytest.approx(np.nanpercentile(vals, 2.0))
+    assert hi == pytest.approx(np.nanpercentile(vals, 98.0))
+    lo2, hi2 = default_clim(vals, style, clip_override=(-3.0, 3.0))
+    assert (lo2, hi2) == (lo, hi)
+
+
+def test_default_clim_center_symmetric():
+    style = FieldStyle(center=0.0)
+    vals = np.linspace(-1.0, 10.0, 1000)  # asymmetric spread
+    lo, hi = default_clim(vals, style)
+    assert lo == pytest.approx(-hi)  # symmetric about 0
+    assert hi == pytest.approx(np.nanpercentile(vals, 98.0))  # larger excursion
+
+
+def test_default_clim_percentiles():
+    style = FieldStyle()
+    vals = np.concatenate([np.linspace(0, 1, 1000), [np.nan] * 50])
+    lo, hi = default_clim(vals, style)
+    assert lo == pytest.approx(0.02, abs=1e-2)
+    assert hi == pytest.approx(0.98, abs=1e-2)
+
+
+# ---------------------------------------------------------------------------
+# Figure assemblers (smoke tests: each writes a non-empty PNG)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def synthetic_scene():
+    """Tiny (K, J, I) fields + a straight front axis, enough to render."""
+    rng = np.random.default_rng(42)
+    K, H, W = 6, 20, 40
+    color = rng.normal(size=(K, H, W))
+    sigma0 = np.sort(rng.normal(25.0, 0.5, size=(K, H, W)), axis=0)
+    Z = -np.linspace(1.0, 60.0, K)
+    m = _straight_horizontal(H, W)
+    axis = curtains.extract_main_axis(m)
+    metrics = curtains.path_metrics(axis)
+    return color, sigma0, Z, axis, metrics
+
+
+def test_figure_main_axis_smoke(synthetic_scene, tmp_path):
+    color, sigma0, Z, axis, metrics = synthetic_scene
+    out = curtains.figure_main_axis(
+        color, sigma0, Z, axis, metrics, tmp_path / "main.png",
+        clim=(-2.0, 2.0), color_title="test",
+    )
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_figure_offsets_smoke(synthetic_scene, tmp_path):
+    color, sigma0, Z, axis, metrics = synthetic_scene
+    out = curtains.figure_offsets(
+        color, sigma0, Z, axis, metrics, 2, tmp_path / "offsets.png",
+        clim=(-2.0, 2.0),
+    )
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_figure_perpendicular_smoke(synthetic_scene, tmp_path):
+    color, sigma0, Z, axis, metrics = synthetic_scene
+    idx = axis.shape[0] // 2
+    perp = curtains.perpendicular_path(axis, metrics["normals"], idx, 5)
+    # Without lon/lat: pixel axis only.
+    out = curtains.figure_perpendicular(
+        color, sigma0, Z, perp, 5, tmp_path / "perp.png",
+    )
+    assert out.exists() and out.stat().st_size > 0
+    # With lon/lat: adds the km twin axis.
+    H, W = 20, 40
+    XC = np.tile(np.arange(W) * 0.01, (H, 1))
+    YC = np.full((H, W), 30.0)
+    out2 = curtains.figure_perpendicular(
+        color, sigma0, Z, perp, 5, tmp_path / "perp_km.png",
+        XC_rect=XC, YC_rect=YC,
+    )
+    assert out2.exists() and out2.stat().st_size > 0

--- a/fronts/tests/test_curtains.py
+++ b/fronts/tests/test_curtains.py
@@ -198,6 +198,59 @@ def test_perpendicular_path_geometry():
     assert np.allclose(perp[:, 1], axis[idx, 1], atol=1e-9)
 
 
+def test_trim_offset_loops_straight_keeps_all():
+    m = _straight_horizontal()
+    axis = curtains.extract_main_axis(m)
+    met = curtains.path_metrics(axis)
+    a, _ = curtains.offset_paths(axis, met["normals"], 2)
+    for p in a:
+        assert curtains.trim_offset_loops(p).all()  # no loops -> keep everything
+
+
+def test_trim_offset_loops_removes_crossing():
+    # Hand-built polyline with an explicit loop (figure-eight pinch).
+    p = np.array([
+        [0, 0], [0, 1], [0, 2], [0, 3], [0, 4],
+        [1, 3], [1, 2],            # fold back (crosses the outgoing run)
+        [0, 5], [0, 6], [0, 7],
+    ], dtype=float)
+    keep = curtains.trim_offset_loops(p)
+    kept = p[keep]
+    # The trimmed line must have no self-intersections among its segments.
+    n = kept.shape[0]
+    for a in range(n - 1):
+        for b in range(a + 2, n - 1):
+            assert not curtains._segments_intersect(
+                kept[a], kept[a + 1], kept[b], kept[b + 1])
+    # And it stays shorter than or equal to the original.
+    assert kept.shape[0] <= p.shape[0]
+
+
+def test_transect_front_crossings_straight():
+    # A single straight front: a perpendicular at mid-span crosses it once.
+    m = _straight_horizontal()
+    axis = curtains.extract_main_axis(m)
+    met = curtains.path_metrics(axis)
+    counts = curtains.transect_front_crossings(axis, met["normals"], m, 6)
+    mid = axis.shape[0] // 2
+    assert counts[mid] == 1
+
+
+def test_transect_front_crossings_double():
+    # Two parallel horizontal fronts 4 px apart: a tall vertical transect
+    # through the middle crosses both.
+    H = W = 30
+    m = np.zeros((H, W), bool)
+    m[12, 5:25] = True
+    m[16, 5:25] = True
+    # Build a single-front axis on the first line; normals point in +/- j.
+    axis = np.column_stack([np.full(20, 12), np.arange(5, 25)]).astype(int)
+    met = curtains.path_metrics(axis)
+    counts = curtains.transect_front_crossings(axis, met["normals"], m, 8)
+    mid = 10
+    assert counts[mid] >= 2
+
+
 def test_pick_extremum_index():
     K, L = 4, 12
     cur = np.full((K, L), 1.0)

--- a/fronts/viz/curtains.py
+++ b/fronts/viz/curtains.py
@@ -46,6 +46,7 @@ Design notes
 # stdlib
 from __future__ import annotations
 import heapq
+import logging
 from typing import Sequence
 
 # numerical / plotting
@@ -54,6 +55,8 @@ from scipy import ndimage as scimg
 import matplotlib
 matplotlib.use("Agg")  # headless-safe; pair to off-screen rendering
 import matplotlib.pyplot as plt  # noqa: E402
+
+log = logging.getLogger(__name__)
 
 
 def _decompose_front_branches(front_mask: np.ndarray):
@@ -449,15 +452,24 @@ def _segments_intersect(p1, p2, p3, p4) -> bool:
 
 
 def trim_offset_loops(offset_path: np.ndarray) -> np.ndarray:
-    """Remove self-intersection loops from an offset polyline ("sew" it shut).
+    """Trim self-crossing loops out of an offset line so it stays continuous.
 
-    When an offset is thrown off the concave side of a bend it can fold back
-    and cross itself.  This excises the looped vertices between each pair of
-    crossing segments, leaving a shorter but crossing-free polyline -- exactly
-    the "the line can just be sewn together to not include this part" behaviour.
+    An offset line traced along the inside of a sharp bend can fold back and
+    cross over itself, forming a small loop.  This function cuts each loop
+    out: wherever two segments of the line cross, the points between them are
+    dropped and the line is sewn back together at the crossing.  The result
+    is a shorter line that never overlaps itself.
 
-    Iterative: find the first pair of non-adjacent segments that cross, drop the
-    vertices strictly between them, and repeat until no crossings remain.
+    It works iteratively: find the first place the line crosses itself, cut
+    out the loop, then start over, until no crossings remain.
+
+    Performance note: each pass compares every segment against every other
+    (O(L^2)), and cutting a loop restarts the pass, so the worst case is
+    ~O(L^3).  That is fast for typical lines (tens to low hundreds of
+    points).  As a safeguard, the number of cuts is capped at L (each cut
+    removes at least one point, so more is impossible); if the cap is
+    somehow hit, the line is returned with any remaining crossings intact
+    and a warning is logged, rather than stalling the render.
 
     Parameters
     ----------
@@ -477,7 +489,14 @@ def trim_offset_loops(offset_path: np.ndarray) -> np.ndarray:
         return np.ones(L, dtype=bool)
     idx = list(range(L))
     changed = True
+    n_excisions = 0
     while changed and len(idx) >= 4:
+        if n_excisions >= L:  # each excision removes >=1 vertex; see docstring
+            log.warning(
+                "trim_offset_loops: excision cap (%d) reached with crossings "
+                "remaining; leaving offset partially untrimmed.", L,
+            )
+            break
         changed = False
         m = len(idx)
         for a in range(m - 1):
@@ -488,10 +507,14 @@ def trim_offset_loops(offset_path: np.ndarray) -> np.ndarray:
                 ):
                     # Excise the loop: drop vertices a+1 .. b inclusive.
                     del idx[a + 1:b + 1]
+                    n_excisions += 1
                     changed = True
                     break
             if changed:
                 break
+    if n_excisions:
+        log.debug("trim_offset_loops: %d loop(s) excised, %d/%d vertices kept.",
+                  n_excisions, len(idx), L)
     mask = np.zeros(L, dtype=bool)
     mask[idx] = True
     return mask

--- a/fronts/viz/curtains.py
+++ b/fronts/viz/curtains.py
@@ -704,7 +704,7 @@ def plot_curtain_panel(
         else:
             clim = (0.0, 1.0)
 
-    cmap_obj = matplotlib.cm.get_cmap(cmap).copy()
+    cmap_obj = plt.get_cmap(cmap).copy()
     cmap_obj.set_bad(nan_color)
 
     # pcolormesh needs cell edges; build them from the column centres (dist_px)
@@ -863,24 +863,33 @@ def figure_offsets(
     title: str | None = None,
     trim: bool = True,
 ):
-    """Figure 2 -- along-front curtains with offsets (two columns).
+    """Figure 2 -- along-front curtains: summary means + individual offsets.
 
-    Row 0 of both columns is the main-axis curtain itself.  Rows 1..N show
-    offsets 1..N pixels to side A (left column) and side B (right column).
+    Layout is ``n_offsets + 2`` rows x 2 columns:
+
+    * **Row 0** -- main-axis curtain (left) and the **mean over all** ``2N``
+      offsets (right).  The all-offset mean is a *dilation* of the front: the
+      average field in a band ``1..N`` px to either side.
+    * **Row 1** -- mean over the **+** offsets (left) and mean over the **-**
+      offsets (right).  These are *directional dilations* (one side of the
+      front each).
+    * **Rows 2..N+1** -- the individual offsets: offset ``r`` px on the +side
+      (left) and -side (right).
 
     When ``trim`` is True (default), each offset polyline is "sewn" shut with
     :func:`trim_offset_loops` -- the self-intersection loops on the concave
-    side of bends are excised and those columns render as neutral-gray gaps,
-    so the curtain only shows the crossing-free part of each offset.  When
-    ``trim`` is False the loops are kept and instead shaded magenta via
-    :func:`offset_quality_flags`.
+    side of bends are excised and those columns render as neutral-gray gaps.
+    The trimmed (NaN) columns are excluded from the row-0/row-1 means via
+    ``nanmean``, so each averaged column only pools the offsets whose geometry
+    is valid there.  When ``trim`` is False the loops are kept and shaded
+    magenta via :func:`offset_quality_flags` (and counted in the means).
 
     Parameters
     ----------
     color_field3d, sigma0_field3d, Z, axis_path, metrics
         As in :func:`figure_main_axis`.
     n_offsets : int
-        Number of offset rows per side.
+        Number of individual offset rows per side (``N``).
     output_path : str or pathlib.Path
         PNG output path.
     levels, clim, cmap, color_title, mark_index, title
@@ -892,6 +901,7 @@ def figure_offsets(
         The output path.
     """
     from pathlib import Path
+    import warnings
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -899,62 +909,95 @@ def figure_offsets(
     dist_px = metrics["dist_px"]
     dist_km = metrics["dist_km"]
 
-    n_rows = n_offsets + 1
-    fig, axes = plt.subplots(
-        n_rows, 2, figsize=(16, 3.2 * n_rows), squeeze=False,
-    )
-
     # Shared clim across all panels for comparability: derive from the axis
     # curtain if not supplied.
     axis_color = sample_curtain(color_field3d, axis_path)
+    axis_sigma0 = sample_curtain(sigma0_field3d, axis_path)
     if clim is None and np.isfinite(axis_color).any():
         clim = (
             float(np.nanpercentile(axis_color, 2)),
             float(np.nanpercentile(axis_color, 98)),
         )
 
-    # Per-column path lists: row 0 = axis (both columns), rows below = offsets.
-    col_paths = {
-        0: [axis_path] + side_a,   # side A column
-        1: [axis_path] + side_b,   # side B column
-    }
-    col_label = {0: "side +n", 1: "side -n"}
+    def _sample_offset(pth):
+        """Sample one offset path; trim looped columns to NaN (or flag them)."""
+        cc = sample_curtain(color_field3d, pth)
+        ss = sample_curtain(sigma0_field3d, pth)
+        flags = None
+        n_drop = 0
+        if trim:
+            keep = trim_offset_loops(pth)
+            n_drop = int((~keep).sum())
+            cc[:, ~keep] = np.nan
+            ss[:, ~keep] = np.nan
+        else:
+            flags = offset_quality_flags(pth)
+        return cc, ss, flags, n_drop
 
-    for col in (0, 1):
-        for row, pth in enumerate(col_paths[col]):
-            ax = axes[row][col]
-            color_curtain = sample_curtain(color_field3d, pth)
-            sigma0_curtain = sample_curtain(sigma0_field3d, pth)
-            flags = None
-            if row == 0:
-                row_title = f"{col_label[col]}: main axis (offset 0)"
-                mk = mark_index
-            else:
-                mk = None
-                if trim:
-                    keep = trim_offset_loops(pth)
-                    n_drop = int((~keep).sum())
-                    # NaN the looped columns so they render as gray gaps.
-                    color_curtain[:, ~keep] = np.nan
-                    sigma0_curtain[:, ~keep] = np.nan
-                    row_title = (f"{col_label[col]}: offset {row} px"
-                                 + (f"  [{n_drop} looped cols trimmed]"
-                                    if n_drop else ""))
-                else:
-                    flags = offset_quality_flags(pth)
-                    n_flag = int(flags.sum())
-                    row_title = (f"{col_label[col]}: offset {row} px"
-                                 + (f"  [{n_flag} overlap cols shaded]"
-                                    if n_flag else ""))
-            plot_curtain_panel(
-                ax, dist_px, Z, color_curtain, sigma0_curtain,
-                dist_km=dist_km, levels=levels, clim=clim, cmap=cmap,
-                color_title=color_title, overlap_flags=flags,
-                mark_index=mk, title=row_title,
-                add_colorbar=(col == 1),  # one colorbar per row, on the right
-            )
+    # Sample every individual offset once; reuse for both the rows and the
+    # mean panels.
+    a_samples = [_sample_offset(p) for p in side_a]   # +side, offsets 1..N
+    b_samples = [_sample_offset(p) for p in side_b]   # -side, offsets 1..N
 
-    fig.suptitle(title or "Along-front curtains with offsets", fontsize=13)
+    def _nanmean(stack_color, stack_sigma0):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            mc = np.nanmean(np.stack(stack_color), axis=0)
+            ms = np.nanmean(np.stack(stack_sigma0), axis=0)
+        return mc, ms
+
+    pos_c = [s[0] for s in a_samples]
+    pos_s = [s[1] for s in a_samples]
+    neg_c = [s[0] for s in b_samples]
+    neg_s = [s[1] for s in b_samples]
+    mean_all_c, mean_all_s = _nanmean(pos_c + neg_c, pos_s + neg_s)
+    mean_pos_c, mean_pos_s = _nanmean(pos_c, pos_s)
+    mean_neg_c, mean_neg_s = _nanmean(neg_c, neg_s)
+
+    n_rows = n_offsets + 2
+    fig, axes = plt.subplots(
+        n_rows, 2, figsize=(16, 3.2 * n_rows), squeeze=False,
+    )
+
+    def _panel(ax, cc, ss, *, title, flags=None, mk=None, cbar=False):
+        plot_curtain_panel(
+            ax, dist_px, Z, cc, ss,
+            dist_km=dist_km, levels=levels, clim=clim, cmap=cmap,
+            color_title=color_title, overlap_flags=flags,
+            mark_index=mk, title=title, add_colorbar=cbar,
+        )
+
+    # ----- Row 0: main axis | mean over ALL offsets (dilation) -----
+    _panel(axes[0][0], axis_color, axis_sigma0,
+           title="main axis (offset 0)", mk=mark_index)
+    _panel(axes[0][1], mean_all_c, mean_all_s,
+           title=f"mean of all +/-{n_offsets} offsets (dilation)",
+           mk=mark_index, cbar=True)
+
+    # ----- Row 1: mean over + offsets | mean over - offsets -----
+    _panel(axes[1][0], mean_pos_c, mean_pos_s,
+           title=f"mean of +offsets 1..{n_offsets} (+dilation)", mk=mark_index)
+    _panel(axes[1][1], mean_neg_c, mean_neg_s,
+           title=f"mean of -offsets 1..{n_offsets} (-dilation)",
+           mk=mark_index, cbar=True)
+
+    # ----- Rows 2..N+1: individual offsets (+side left, -side right) -----
+    for k in range(n_offsets):
+        row = k + 2
+        ac, as_, aflags, adrop = a_samples[k]
+        bc, bs, bflags, bdrop = b_samples[k]
+        note = (lambda n: f"  [{n} looped cols trimmed]" if (trim and n) else
+                (f"  [{n} overlap cols shaded]" if (not trim and n) else ""))
+        a_n = adrop if trim else (int(aflags.sum()) if aflags is not None else 0)
+        b_n = bdrop if trim else (int(bflags.sum()) if bflags is not None else 0)
+        _panel(axes[row][0], ac, as_,
+               title=f"+side: offset {k + 1} px" + note(a_n), flags=aflags)
+        _panel(axes[row][1], bc, bs,
+               title=f"-side: offset {k + 1} px" + note(b_n), flags=bflags,
+               cbar=True)
+
+    fig.suptitle(title or "Along-front curtains: dilation + offsets",
+                 fontsize=13)
     fig.tight_layout(rect=(0, 0, 1, 0.98))
     fig.savefig(output_path, dpi=150, bbox_inches="tight")
     plt.close(fig)

--- a/fronts/viz/curtains.py
+++ b/fronts/viz/curtains.py
@@ -1,0 +1,898 @@
+"""
+Builders for 2-D "curtain" cross-sections of labelled fronts in LLC4320 tiles.
+
+A *curtain* is a vertical cross-section sampled along a path of pixels through
+a tile:
+
+* x-axis -- distance along the path (pixels, with an optional km twin),
+* y-axis -- depth (the LLC ``Z`` axis, metres, negative downward),
+* color  -- a configurable field (default the Richardson number ``Ri``),
+* contours -- isopycnals (sigma0 surfaces) overlaid on top.
+
+This module is the 2-D counterpart of ``fronts/viz/fronts_3d.py``.  It reuses
+that module's :func:`~fronts.viz.fronts_3d.decompose_front_branches` to split a
+thinned front skeleton into branch polylines, then assembles the *main axis*
+(the longest end-to-end path, ignoring side branches), throws *offset* paths to
+either side of it, and cuts a *perpendicular* transect at a chosen point.
+
+The sampling core (:func:`sample_curtain`) mirrors the inner loop of
+``fronts_3d.build_front_curtain`` -- ``scipy.ndimage.map_coordinates`` along a
+``(j, i)`` polyline across every depth level -- but returns a plain ``(K, L)``
+array for matplotlib rather than a PyVista ribbon.
+
+Rendering is static matplotlib (Agg), matching the repo's 2-D companion figures
+in ``fronts/viz/insets.py``.
+
+Design notes
+------------
+* **Main-axis columns are the real front pixels.**  No resampling onto evenly
+  spaced points: every pixel along the diameter path is one curtain column.
+  Distance-in-km is integrated great-circle distance between consecutive real
+  pixels, so the km axis is just a relabelling of the same columns.
+* **Smoothing affects only directions.**  The optional tangential/normal
+  smoothing (``smooth_window``) is applied to the unit-direction field used to
+  throw offsets and the perpendicular transect -- never to the main-axis
+  column positions.  A jagged single-pixel skeleton produces wildly swinging
+  raw normals that make adjacent offset points collide immediately; smoothing
+  averages the kink out.
+* **Offset self-overlap is detected, not hidden.**  Where offset points from
+  different axis positions land within < 1 px of each other (the concave side
+  of a genuine bend, or residual skeleton noise), the affected columns are
+  flagged and shaded on the figure so the curtain still renders but the
+  unreliable region is obvious.  The more-correct centre-of-curvature offset is
+  a documented follow-up, not implemented here.
+"""
+
+# stdlib
+from __future__ import annotations
+import heapq
+from typing import Sequence
+
+# numerical / plotting
+import numpy as np
+from scipy import ndimage as scimg
+import matplotlib
+matplotlib.use("Agg")  # headless-safe; pair to off-screen rendering
+import matplotlib.pyplot as plt  # noqa: E402
+
+
+def _decompose_front_branches(front_mask: np.ndarray):
+    """Lazily import the 3-D module's branch decomposition.
+
+    ``fronts/viz/fronts_3d.py`` imports PyVista at module load, but the branch
+    decomposition itself is pure NumPy/SciPy.  Importing it lazily here keeps
+    the 2-D curtain viewer usable without a 3-D rendering stack installed,
+    while still reusing the identical skeleton-handling code.
+    """
+    from fronts.viz.fronts_3d import decompose_front_branches
+    return decompose_front_branches(front_mask)
+
+
+# ---------------------------------------------------------------------------
+# Main-axis extraction (longest end-to-end path through the skeleton)
+# ---------------------------------------------------------------------------
+
+def _branch_length(branch: np.ndarray) -> float:
+    """Arc length of a ``(L, 2)`` (j, i) polyline in pixels.
+
+    Consecutive 4-connected steps contribute 1, diagonal steps ``sqrt(2)``.
+
+    Parameters
+    ----------
+    branch : numpy.ndarray
+        ``(L, 2)`` integer array of ``(j, i)`` pixel coordinates.
+
+    Returns
+    -------
+    float
+        Sum of Euclidean distances between consecutive pixels (0 for a
+        single-pixel branch).
+    """
+    if branch.shape[0] < 2:
+        return 0.0
+    d = np.diff(branch.astype(np.float64), axis=0)
+    return float(np.sqrt((d ** 2).sum(axis=1)).sum())
+
+
+def extract_main_axis(front_mask: np.ndarray) -> np.ndarray:
+    """Return the longest end-to-end path through a thinned front skeleton.
+
+    The skeleton is decomposed into branches between junctions/endpoints by
+    :func:`fronts.viz.fronts_3d.decompose_front_branches`.  Those branches form
+    a graph whose nodes are the branch end pixels and whose edges are weighted
+    by branch arc length.  The *main axis* is the graph diameter -- the longest
+    end-to-end shortest path -- found with two Dijkstra sweeps (a longest-path
+    search on a tree; for the rare cyclic skeleton the double-sweep still
+    returns a near-diameter path, which is sufficient for a front backbone).
+
+    Side branches are dropped: only the branches lying on the diameter path are
+    concatenated into the returned polyline.
+
+    Parameters
+    ----------
+    front_mask : numpy.ndarray
+        2-D boolean mask, True at the selected front's (thinned) pixels.
+
+    Returns
+    -------
+    numpy.ndarray
+        ``(L, 2)`` integer array of ``(j, i)`` pixel coordinates, ordered along
+        the main axis.  Falls back to the single longest branch if the graph is
+        degenerate, or to the lone pixel for a single-pixel mask.
+
+    Raises
+    ------
+    ValueError
+        If ``front_mask`` has no True pixels.
+    """
+    if not front_mask.any():
+        raise ValueError("front_mask has no True pixels; nothing to trace.")
+
+    branches = _decompose_front_branches(front_mask)
+    # Drop zero-length (single-pixel) branches for graph building but remember
+    # them in case the whole front is a single pixel.
+    poly_branches = [b for b in branches if b.shape[0] >= 2]
+    if not poly_branches:
+        # Single isolated pixel (or a handful) -- just return the longest.
+        return max(branches, key=lambda b: b.shape[0])
+
+    # Build a node index keyed by pixel coordinate of every branch endpoint.
+    node_id: dict[tuple[int, int], int] = {}
+
+    def _node(jy: int, ix: int) -> int:
+        key = (int(jy), int(ix))
+        if key not in node_id:
+            node_id[key] = len(node_id)
+        return node_id[key]
+
+    # adjacency: node -> list of (neighbour_node, weight, branch_index, reversed)
+    adj: dict[int, list[tuple[int, float, int, bool]]] = {}
+    for b_idx, branch in enumerate(poly_branches):
+        a = _node(branch[0, 0], branch[0, 1])
+        b = _node(branch[-1, 0], branch[-1, 1])
+        w = _branch_length(branch)
+        adj.setdefault(a, []).append((b, w, b_idx, False))
+        adj.setdefault(b, []).append((a, w, b_idx, True))
+
+    def _dijkstra(source: int) -> tuple[np.ndarray, dict[int, tuple[int, int, bool]]]:
+        """Shortest-path distances + predecessor edges from ``source``."""
+        n = len(node_id)
+        dist = np.full(n, np.inf)
+        dist[source] = 0.0
+        prev: dict[int, tuple[int, int, bool]] = {}  # node -> (prev_node, b_idx, reversed)
+        pq: list[tuple[float, int]] = [(0.0, source)]
+        while pq:
+            d, u = heapq.heappop(pq)
+            if d > dist[u]:
+                continue
+            for v, w, b_idx, rev in adj.get(u, []):
+                nd = d + w
+                if nd < dist[v]:
+                    dist[v] = nd
+                    prev[v] = (u, b_idx, rev)
+                    heapq.heappush(pq, (nd, v))
+        return dist, prev
+
+    # Double sweep: farthest node from an arbitrary start, then farthest from
+    # that node -> the two endpoints of the diameter.
+    start = next(iter(node_id.values()))
+    dist0, _ = _dijkstra(start)
+    end_a = int(np.argmax(np.where(np.isfinite(dist0), dist0, -1.0)))
+    dist1, prev1 = _dijkstra(end_a)
+    end_b = int(np.argmax(np.where(np.isfinite(dist1), dist1, -1.0)))
+
+    # Walk predecessors from end_b back to end_a, collecting branch indices.
+    path_edges: list[tuple[int, bool]] = []  # (branch_index, reversed)
+    cur = end_b
+    while cur != end_a and cur in prev1:
+        pnode, b_idx, rev = prev1[cur]
+        path_edges.append((b_idx, rev))
+        cur = pnode
+    path_edges.reverse()
+
+    if not path_edges:
+        # Disconnected / degenerate -- fall back to the single longest branch.
+        return max(poly_branches, key=_branch_length)
+
+    # Concatenate branch polylines along the path, orienting each so its tail
+    # matches the previous branch's head, and de-duplicating shared junction
+    # pixels at the joins.
+    pieces: list[np.ndarray] = []
+    for k, (b_idx, rev) in enumerate(path_edges):
+        seg = poly_branches[b_idx]
+        if rev:
+            seg = seg[::-1]
+        if k > 0:
+            # Drop the first pixel if it duplicates the previous tail.
+            if np.array_equal(seg[0], pieces[-1][-1]):
+                seg = seg[1:]
+        if seg.shape[0] > 0:
+            pieces.append(seg)
+    axis = np.concatenate(pieces, axis=0)
+    return axis.astype(np.int32)
+
+
+# ---------------------------------------------------------------------------
+# Path metrics: distances + (optionally smoothed) tangents/normals
+# ---------------------------------------------------------------------------
+
+def _great_circle_step_km(lat1, lon1, lat2, lon2) -> np.ndarray:
+    """Great-circle distance (km) between consecutive lon/lat samples (haversine)."""
+    R = 6371.0088  # mean Earth radius, km
+    p1 = np.radians(lat1)
+    p2 = np.radians(lat2)
+    dphi = np.radians(lat2 - lat1)
+    dlmb = np.radians(lon2 - lon1)
+    a = (np.sin(dphi / 2.0) ** 2
+         + np.cos(p1) * np.cos(p2) * np.sin(dlmb / 2.0) ** 2)
+    return 2.0 * R * np.arcsin(np.sqrt(np.clip(a, 0.0, 1.0)))
+
+
+def path_metrics(
+    path: np.ndarray,
+    XC_rect: np.ndarray | None = None,
+    YC_rect: np.ndarray | None = None,
+    *,
+    smooth: bool = False,
+    smooth_window: int = 5,
+) -> dict:
+    """Per-pixel distance + unit tangent/normal for a ``(j, i)`` path.
+
+    The returned arrays are aligned 1:1 with ``path`` -- one entry per real
+    pixel; nothing is resampled onto new positions.  ``smooth`` controls *only*
+    the direction field (tangents and normals), never the distances or the path
+    itself.
+
+    Parameters
+    ----------
+    path : numpy.ndarray
+        ``(L, 2)`` integer/float ``(j, i)`` pixel coordinates.
+    XC_rect, YC_rect : numpy.ndarray, optional
+        Longitude / latitude on the rect-tile-local frame, shape
+        ``(TILE_SIZE, TILE_SIZE)``.  When supplied the cumulative great-circle
+        distance in km is computed; otherwise ``dist_km`` is None.
+    smooth : bool, optional
+        If True, smooth the tangential direction with a moving average of width
+        ``smooth_window`` before deriving normals.  Default False (raw, jagged).
+    smooth_window : int, optional
+        Odd window length in pixels for the tangent smoothing (default 5).
+        Ignored when ``smooth`` is False.
+
+    Returns
+    -------
+    dict
+        Keys: ``dist_px`` (L,), ``dist_km`` (L,) or None, ``tangents`` (L, 2)
+        unit ``(dj, di)``, ``normals`` (L, 2) unit ``(dj, di)`` rotated +90 deg,
+        ``smoothed`` (bool).
+    """
+    pts = np.asarray(path, dtype=np.float64)
+    L = pts.shape[0]
+
+    # Cumulative pixel distance (Euclidean between consecutive pixels).
+    if L >= 2:
+        step = np.sqrt((np.diff(pts, axis=0) ** 2).sum(axis=1))
+        dist_px = np.concatenate([[0.0], np.cumsum(step)])
+    else:
+        dist_px = np.zeros(L)
+
+    # Cumulative km distance from lon/lat at the real pixels.
+    dist_km = None
+    if XC_rect is not None and YC_rect is not None and L >= 1:
+        jj = np.clip(np.round(pts[:, 0]).astype(int), 0, XC_rect.shape[0] - 1)
+        ii = np.clip(np.round(pts[:, 1]).astype(int), 0, XC_rect.shape[1] - 1)
+        lon = XC_rect[jj, ii]
+        lat = YC_rect[jj, ii]
+        if L >= 2:
+            step_km = _great_circle_step_km(lat[:-1], lon[:-1], lat[1:], lon[1:])
+            dist_km = np.concatenate([[0.0], np.cumsum(step_km)])
+        else:
+            dist_km = np.zeros(L)
+
+    # Tangents via central differences on the (un-smoothed) pixel positions.
+    if L >= 2:
+        tang = np.gradient(pts, axis=0)  # (L, 2)
+    else:
+        tang = np.zeros((L, 2))
+        tang[:, 1] = 1.0  # arbitrary unit direction for a single pixel
+
+    if smooth and L >= 3:
+        w = max(3, int(smooth_window) | 1)  # force odd, >= 3
+        kernel = np.ones(w) / w
+        # Smooth each component of the tangent direction, then renormalise.
+        tj = np.convolve(tang[:, 0], kernel, mode="same")
+        ti = np.convolve(tang[:, 1], kernel, mode="same")
+        tang = np.column_stack([tj, ti])
+
+    norm = np.sqrt((tang ** 2).sum(axis=1))
+    norm[norm == 0] = 1.0
+    tangents = tang / norm[:, None]
+
+    # Normal = tangent rotated +90 deg in (j, i): (dj, di) -> (-di, dj)... but
+    # we keep a consistent right-hand convention: n = (di, -dj) gives a vector
+    # 90 deg clockwise.  Either sign is fine as long as +offset/-offset are
+    # mirror images; we pick n = (-t_i, t_j) so side A / side B are consistent.
+    normals = np.column_stack([-tangents[:, 1], tangents[:, 0]])
+
+    return {
+        "dist_px": dist_px,
+        "dist_km": dist_km,
+        "tangents": tangents,
+        "normals": normals,
+        "smoothed": bool(smooth),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Offset + perpendicular path construction
+# ---------------------------------------------------------------------------
+
+def offset_paths(
+    path: np.ndarray,
+    normals: np.ndarray,
+    n_offsets: int,
+) -> tuple[list[np.ndarray], list[np.ndarray]]:
+    """Build offset polylines 1..n pixels to either side of a path.
+
+    Parameters
+    ----------
+    path : numpy.ndarray
+        ``(L, 2)`` ``(j, i)`` main-axis pixel coordinates (float ok).
+    normals : numpy.ndarray
+        ``(L, 2)`` unit normal per pixel (from :func:`path_metrics`).
+    n_offsets : int
+        Number of offset steps per side.
+
+    Returns
+    -------
+    side_a, side_b : list of numpy.ndarray
+        ``side_a[k]`` is the path shifted ``(k + 1)`` pixels along ``+normal``;
+        ``side_b[k]`` along ``-normal``.  Each is an ``(L, 2)`` float array (not
+        rounded -- sampling interpolates).
+    """
+    pts = np.asarray(path, dtype=np.float64)
+    side_a: list[np.ndarray] = []
+    side_b: list[np.ndarray] = []
+    for k in range(1, int(n_offsets) + 1):
+        side_a.append(pts + k * normals)
+        side_b.append(pts - k * normals)
+    return side_a, side_b
+
+
+def perpendicular_path(
+    path: np.ndarray,
+    normals: np.ndarray,
+    idx: int,
+    half_width: int,
+) -> np.ndarray:
+    """Cross-front transect centered on ``path[idx]`` along its normal.
+
+    Parameters
+    ----------
+    path : numpy.ndarray
+        ``(L, 2)`` ``(j, i)`` main-axis coordinates.
+    normals : numpy.ndarray
+        ``(L, 2)`` unit normals from :func:`path_metrics`.
+    idx : int
+        Index along the path at which to cut the transect.
+    half_width : int
+        Number of pixels on each side of the axis (transect length is
+        ``2 * half_width + 1``).
+
+    Returns
+    -------
+    numpy.ndarray
+        ``(2 * half_width + 1, 2)`` float ``(j, i)`` coordinates, ordered from
+        ``-half_width`` (side B) through 0 (the axis point) to ``+half_width``
+        (side A).
+    """
+    idx = int(np.clip(idx, 0, path.shape[0] - 1))
+    origin = np.asarray(path[idx], dtype=np.float64)
+    n = np.asarray(normals[idx], dtype=np.float64)
+    steps = np.arange(-int(half_width), int(half_width) + 1)
+    return origin[None, :] + steps[:, None] * n[None, :]
+
+
+def offset_quality_flags(
+    offset_path: np.ndarray,
+    *,
+    min_separation_px: float = 1.0,
+) -> np.ndarray:
+    """Flag columns of an offset path that self-overlap (option (b)).
+
+    A column is flagged when its offset point lands within
+    ``min_separation_px`` of *any other* column's offset point -- the signature
+    of the concave side of a bend folding back on itself (or of residual
+    skeleton noise when smoothing is off).  The curtain still renders; the
+    caller shades flagged columns.
+
+    Parameters
+    ----------
+    offset_path : numpy.ndarray
+        ``(L, 2)`` offset polyline coordinates.
+    min_separation_px : float, optional
+        Collision threshold in pixels (default 1.0).
+
+    Returns
+    -------
+    numpy.ndarray
+        ``(L,)`` boolean array, True where the offset point collides with a
+        non-adjacent column.
+    """
+    pts = np.asarray(offset_path, dtype=np.float64)
+    L = pts.shape[0]
+    flags = np.zeros(L, dtype=bool)
+    if L < 3:
+        return flags
+    # Pairwise distance, but only flag collisions between columns that are not
+    # immediate neighbours (adjacent columns are *supposed* to be ~1 px apart).
+    for a in range(L):
+        d = np.sqrt(((pts - pts[a]) ** 2).sum(axis=1))
+        d[max(0, a - 1):min(L, a + 2)] = np.inf  # ignore self + neighbours
+        if np.any(d < min_separation_px):
+            flags[a] = True
+    return flags
+
+
+# ---------------------------------------------------------------------------
+# Curtain sampling
+# ---------------------------------------------------------------------------
+
+def sample_curtain(
+    field3d: np.ndarray,
+    path: np.ndarray,
+    *,
+    order: int = 1,
+) -> np.ndarray:
+    """Sample a 3-D field along a ``(j, i)`` path at every depth level.
+
+    Mirrors the inner sampling of
+    :func:`fronts.viz.fronts_3d.build_front_curtain` but returns a plain
+    ``(K, L)`` array.  Off-grid samples (paths leaving the cropped window) come
+    back as NaN via ``mode='constant', cval=nan`` so the renderer can flag them.
+
+    Parameters
+    ----------
+    field3d : numpy.ndarray
+        ``(K, J, I)`` field already cropped/clipped to the curtain window
+        (e.g. cropped + depth-clipped sigma0, or the transformed color field).
+    path : numpy.ndarray
+        ``(L, 2)`` ``(j, i)`` coordinates *in the cropped frame*.
+    order : int, optional
+        Spline interpolation order for ``map_coordinates`` (default 1, linear).
+
+    Returns
+    -------
+    numpy.ndarray
+        ``(K, L)`` sampled field; NaN where the path leaves the window.
+    """
+    K = field3d.shape[0]
+    pts = np.asarray(path, dtype=np.float64)
+    L = pts.shape[0]
+    j_loc = pts[:, 0]
+    i_loc = pts[:, 1]
+    kk, ss = np.meshgrid(np.arange(K), np.arange(L), indexing="ij")
+    coords = np.stack([
+        kk.ravel().astype(np.float64),
+        np.repeat(j_loc[None, :], K, axis=0).ravel(),
+        np.repeat(i_loc[None, :], K, axis=0).ravel(),
+    ], axis=0)
+    sampled = scimg.map_coordinates(
+        field3d, coords, order=order, mode="constant", cval=np.nan,
+    ).reshape(K, L)
+    return sampled
+
+
+def pick_extremum_index(
+    curtain_field: np.ndarray,
+    mode: str = "min",
+) -> int:
+    """Index of the column holding the field's extremum over the full depth.
+
+    Parameters
+    ----------
+    curtain_field : numpy.ndarray
+        ``(K, L)`` sampled (display-space) color field along the main axis.
+    mode : {'min', 'max'}, optional
+        Whether the "most extreme" point is the minimum (default; e.g. lowest
+        Ri = most shear-unstable) or the maximum.
+
+    Returns
+    -------
+    int
+        Column index ``0..L-1`` of the extreme value, searched over all depths
+        (full column).  NaNs are ignored.
+
+    Raises
+    ------
+    ValueError
+        If the curtain is entirely NaN, or ``mode`` is unrecognised.
+    """
+    if mode not in ("min", "max"):
+        raise ValueError(f"mode must be 'min' or 'max', got {mode!r}.")
+    if not np.isfinite(curtain_field).any():
+        raise ValueError("curtain_field is entirely NaN; no extremum.")
+    # Collapse depth: best (min or max) value in each column, then argmin/argmax.
+    if mode == "min":
+        per_col = np.nanmin(curtain_field, axis=0)
+        return int(np.nanargmin(per_col))
+    per_col = np.nanmax(curtain_field, axis=0)
+    return int(np.nanargmax(per_col))
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+def plot_curtain_panel(
+    ax,
+    dist_px: np.ndarray,
+    Z: np.ndarray,
+    color_curtain: np.ndarray,
+    sigma0_curtain: np.ndarray,
+    *,
+    dist_km: np.ndarray | None = None,
+    levels: Sequence[float] | None = None,
+    clim: tuple[float, float] | None = None,
+    cmap: str = "RdYlBu",
+    color_title: str = "",
+    nan_color: str = "#9e9e9e",
+    overlap_flags: np.ndarray | None = None,
+    mld_curtain: np.ndarray | None = None,
+    title: str | None = None,
+    mark_index: int | None = None,
+    add_colorbar: bool = True,
+    contour_color: str = "k",
+) -> None:
+    """Draw a single curtain panel: color field + isopycnal contours.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        Target axes.
+    dist_px : numpy.ndarray
+        ``(L,)`` along-path distance in pixels (the x coordinate of columns).
+    Z : numpy.ndarray
+        ``(K,)`` depth axis in metres (negative downward).
+    color_curtain : numpy.ndarray
+        ``(K, L)`` display-space color field (e.g. log10 Ri).
+    sigma0_curtain : numpy.ndarray
+        ``(K, L)`` sigma0 field for the isopycnal contour overlay.
+    dist_km : numpy.ndarray, optional
+        ``(L,)`` along-path distance in km; when given, a secondary top x-axis
+        labelled in km is attached.
+    levels : sequence of float, optional
+        sigma0 contour levels.  When None no isopycnals are drawn.
+    clim : tuple of (float, float), optional
+        Color limits for ``color_curtain``.  Default 2/98 percentile.
+    cmap : str, optional
+        Colormap for the color field (default ``'RdYlBu'``, the Ri style).
+    color_title : str, optional
+        Colorbar label.
+    nan_color : str, optional
+        Color for NaN cells of the color field (default neutral gray).
+    overlap_flags : numpy.ndarray, optional
+        ``(L,)`` boolean; columns flagged True are shaded (offset self-overlap).
+    mld_curtain : numpy.ndarray, optional
+        ``(L,)`` mixed-layer depth (metres, negative) sampled along the path;
+        drawn as a dashed line when supplied.
+    title : str, optional
+        Panel title.
+    mark_index : int, optional
+        Column index to mark with a vertical line (e.g. the perpendicular
+        point on an along-front panel).
+    add_colorbar : bool, optional
+        Whether to attach a colorbar to this panel (default True).
+    contour_color : str, optional
+        Color of the isopycnal contour lines (default black).
+    """
+    L = dist_px.shape[0]
+    if clim is None:
+        if np.isfinite(color_curtain).any():
+            clim = (
+                float(np.nanpercentile(color_curtain, 2)),
+                float(np.nanpercentile(color_curtain, 98)),
+            )
+        else:
+            clim = (0.0, 1.0)
+
+    cmap_obj = matplotlib.cm.get_cmap(cmap).copy()
+    cmap_obj.set_bad(nan_color)
+
+    # pcolormesh needs cell edges; build them from the column centres (dist_px)
+    # and the depth centres (Z).  Use midpoints + endpoint extrapolation.
+    def _edges(centres: np.ndarray) -> np.ndarray:
+        c = np.asarray(centres, dtype=np.float64)
+        if c.size == 1:
+            return np.array([c[0] - 0.5, c[0] + 0.5])
+        mids = 0.5 * (c[:-1] + c[1:])
+        first = c[0] - (mids[0] - c[0])
+        last = c[-1] + (c[-1] - mids[-1])
+        return np.concatenate([[first], mids, [last]])
+
+    x_edges = _edges(dist_px)
+    z_edges = _edges(Z)
+
+    masked = np.ma.masked_invalid(color_curtain)
+    mesh = ax.pcolormesh(
+        x_edges, z_edges, masked,
+        cmap=cmap_obj, vmin=clim[0], vmax=clim[1], shading="flat",
+    )
+
+    # Isopycnal contours (drawn at column/depth centres).
+    if levels is not None and np.isfinite(sigma0_curtain).any():
+        Xc, Zc = np.meshgrid(dist_px, Z)
+        try:
+            cs = ax.contour(
+                Xc, Zc, sigma0_curtain, levels=list(levels),
+                colors=contour_color, linewidths=0.8,
+            )
+            ax.clabel(cs, inline=True, fontsize=7, fmt="%.2f")
+        except ValueError:
+            pass  # levels outside the data range -> no contours
+
+    # Mixed-layer depth line.
+    if mld_curtain is not None:
+        ax.plot(dist_px, mld_curtain, color="white", lw=1.5, ls="--",
+                label="MLD")
+
+    # Overlap shading: vertical spans on flagged columns.
+    if overlap_flags is not None and overlap_flags.any():
+        x_e = x_edges
+        for c in np.where(overlap_flags)[0]:
+            ax.axvspan(x_e[c], x_e[c + 1], color="magenta", alpha=0.18, lw=0)
+
+    # Mark a chosen column (e.g. the perpendicular point).
+    if mark_index is not None:
+        ax.axvline(dist_px[int(np.clip(mark_index, 0, L - 1))],
+                   color="lime", lw=1.5, ls="-")
+
+    ax.set_xlabel("distance along path [px]")
+    ax.set_ylabel("depth [m]")
+    if title:
+        ax.set_title(title, fontsize=10)
+
+    # Secondary km axis on top.
+    if dist_km is not None:
+        ax_km = ax.twiny()
+        ax_km.set_xlim(ax.get_xlim())
+        # Place ~6 ticks at pixel positions, labelled with km.
+        xticks = np.linspace(dist_px[0], dist_px[-1], 6)
+        # Interpolate km at those pixel positions.
+        km_at = np.interp(xticks, dist_px, dist_km)
+        ax_km.set_xticks(xticks)
+        ax_km.set_xticklabels([f"{v:.1f}" for v in km_at])
+        ax_km.set_xlabel("distance along path [km]")
+
+    if add_colorbar:
+        cbar = ax.figure.colorbar(mesh, ax=ax, shrink=0.85, pad=0.02)
+        cbar.set_label(color_title)
+
+
+# ---------------------------------------------------------------------------
+# Figure assemblers (one per deliverable)
+# ---------------------------------------------------------------------------
+
+def figure_main_axis(
+    color_field3d: np.ndarray,
+    sigma0_field3d: np.ndarray,
+    Z: np.ndarray,
+    axis_path: np.ndarray,
+    metrics: dict,
+    output_path,
+    *,
+    levels: Sequence[float] | None = None,
+    clim: tuple[float, float] | None = None,
+    cmap: str = "RdYlBu",
+    color_title: str = "",
+    mld_curtain: np.ndarray | None = None,
+    mark_index: int | None = None,
+    title: str | None = None,
+):
+    """Figure 1 -- the main-axis curtain (single panel).
+
+    Parameters
+    ----------
+    color_field3d, sigma0_field3d : numpy.ndarray
+        ``(K, J, I)`` cropped+clipped color field and sigma0 (cropped frame).
+    Z : numpy.ndarray
+        ``(K,)`` depth axis.
+    axis_path : numpy.ndarray
+        ``(L, 2)`` main-axis ``(j, i)`` coordinates in the cropped frame.
+    metrics : dict
+        Output of :func:`path_metrics` for ``axis_path``.
+    output_path : str or pathlib.Path
+        PNG output path.
+    levels, clim, cmap, color_title, mld_curtain, mark_index, title
+        Passed through to :func:`plot_curtain_panel`.
+
+    Returns
+    -------
+    pathlib.Path
+        The output path.
+    """
+    from pathlib import Path
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    color_curtain = sample_curtain(color_field3d, axis_path)
+    sigma0_curtain = sample_curtain(sigma0_field3d, axis_path)
+
+    fig, ax = plt.subplots(figsize=(11, 5))
+    plot_curtain_panel(
+        ax, metrics["dist_px"], Z, color_curtain, sigma0_curtain,
+        dist_km=metrics["dist_km"], levels=levels, clim=clim, cmap=cmap,
+        color_title=color_title, mld_curtain=mld_curtain,
+        mark_index=mark_index,
+        title=title or "Main-axis curtain",
+    )
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    return output_path
+
+
+def figure_offsets(
+    color_field3d: np.ndarray,
+    sigma0_field3d: np.ndarray,
+    Z: np.ndarray,
+    axis_path: np.ndarray,
+    metrics: dict,
+    n_offsets: int,
+    output_path,
+    *,
+    levels: Sequence[float] | None = None,
+    clim: tuple[float, float] | None = None,
+    cmap: str = "RdYlBu",
+    color_title: str = "",
+    mark_index: int | None = None,
+    title: str | None = None,
+):
+    """Figure 2 -- along-front curtains with offsets (two columns).
+
+    Row 0 of both columns is the main-axis curtain itself.  Rows 1..N show
+    offsets 1..N pixels to side A (left column) and side B (right column).
+    Columns whose offset geometry self-overlaps are shaded (see
+    :func:`offset_quality_flags`).
+
+    Parameters
+    ----------
+    color_field3d, sigma0_field3d, Z, axis_path, metrics
+        As in :func:`figure_main_axis`.
+    n_offsets : int
+        Number of offset rows per side.
+    output_path : str or pathlib.Path
+        PNG output path.
+    levels, clim, cmap, color_title, mark_index, title
+        Display options.
+
+    Returns
+    -------
+    pathlib.Path
+        The output path.
+    """
+    from pathlib import Path
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    side_a, side_b = offset_paths(axis_path, metrics["normals"], n_offsets)
+    dist_px = metrics["dist_px"]
+    dist_km = metrics["dist_km"]
+
+    n_rows = n_offsets + 1
+    fig, axes = plt.subplots(
+        n_rows, 2, figsize=(16, 3.2 * n_rows), squeeze=False,
+    )
+
+    # Shared clim across all panels for comparability: derive from the axis
+    # curtain if not supplied.
+    axis_color = sample_curtain(color_field3d, axis_path)
+    if clim is None and np.isfinite(axis_color).any():
+        clim = (
+            float(np.nanpercentile(axis_color, 2)),
+            float(np.nanpercentile(axis_color, 98)),
+        )
+
+    # Per-column path lists: row 0 = axis (both columns), rows below = offsets.
+    col_paths = {
+        0: [axis_path] + side_a,   # side A column
+        1: [axis_path] + side_b,   # side B column
+    }
+    col_label = {0: "side +n", 1: "side -n"}
+
+    for col in (0, 1):
+        for row, pth in enumerate(col_paths[col]):
+            ax = axes[row][col]
+            color_curtain = sample_curtain(color_field3d, pth)
+            sigma0_curtain = sample_curtain(sigma0_field3d, pth)
+            flags = None
+            if row == 0:
+                row_title = f"{col_label[col]}: main axis (offset 0)"
+                mk = mark_index
+            else:
+                flags = offset_quality_flags(pth)
+                n_flag = int(flags.sum())
+                row_title = (f"{col_label[col]}: offset {row} px"
+                             + (f"  [{n_flag} overlap cols shaded]"
+                                if n_flag else ""))
+                mk = None
+            plot_curtain_panel(
+                ax, dist_px, Z, color_curtain, sigma0_curtain,
+                dist_km=dist_km, levels=levels, clim=clim, cmap=cmap,
+                color_title=color_title, overlap_flags=flags,
+                mark_index=mk, title=row_title,
+                add_colorbar=(col == 1),  # one colorbar per row, on the right
+            )
+
+    fig.suptitle(title or "Along-front curtains with offsets", fontsize=13)
+    fig.tight_layout(rect=(0, 0, 1, 0.98))
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    return output_path
+
+
+def figure_perpendicular(
+    color_field3d: np.ndarray,
+    sigma0_field3d: np.ndarray,
+    Z: np.ndarray,
+    perp_path: np.ndarray,
+    half_width: int,
+    output_path,
+    *,
+    XC_rect: np.ndarray | None = None,
+    YC_rect: np.ndarray | None = None,
+    levels: Sequence[float] | None = None,
+    clim: tuple[float, float] | None = None,
+    cmap: str = "RdYlBu",
+    color_title: str = "",
+    title: str | None = None,
+):
+    """Figure 3 -- the perpendicular (cross-front) curtain (single panel).
+
+    The x-axis is signed cross-front distance: 0 at the main axis, negative on
+    side B, positive on side A.
+
+    Parameters
+    ----------
+    color_field3d, sigma0_field3d, Z
+        As in :func:`figure_main_axis`.
+    perp_path : numpy.ndarray
+        ``(2*half_width+1, 2)`` transect coordinates from
+        :func:`perpendicular_path`.
+    half_width : int
+        Half-width used to build ``perp_path`` (sets the signed x range).
+    output_path : str or pathlib.Path
+        PNG output path.
+    XC_rect, YC_rect : numpy.ndarray, optional
+        For a km twin axis along the transect.
+    levels, clim, cmap, color_title, title
+        Display options.
+
+    Returns
+    -------
+    pathlib.Path
+        The output path.
+    """
+    from pathlib import Path
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    metrics = path_metrics(perp_path, XC_rect, YC_rect, smooth=False)
+    color_curtain = sample_curtain(color_field3d, perp_path)
+    sigma0_curtain = sample_curtain(sigma0_field3d, perp_path)
+
+    # Signed cross-front distance in pixels: -half_width .. +half_width.
+    signed_px = np.arange(-int(half_width), int(half_width) + 1, dtype=float)
+
+    fig, ax = plt.subplots(figsize=(9, 5))
+    plot_curtain_panel(
+        ax, signed_px, Z, color_curtain, sigma0_curtain,
+        dist_km=None,  # signed axis; km twin handled below if desired
+        levels=levels, clim=clim, cmap=cmap, color_title=color_title,
+        mark_index=int(half_width),  # the axis crossing at 0
+        title=title or "Cross-front (perpendicular) curtain",
+    )
+    ax.set_xlabel("cross-front distance [px]  (0 = front axis)")
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    return output_path

--- a/fronts/viz/curtains.py
+++ b/fronts/viz/curtains.py
@@ -433,6 +433,115 @@ def offset_quality_flags(
     return flags
 
 
+def _cross(a: np.ndarray, b: np.ndarray, c: np.ndarray) -> float:
+    """Signed area of triangle (a, b, c); sign gives orientation of c vs a->b."""
+    return ((b[0] - a[0]) * (c[1] - a[1])
+            - (b[1] - a[1]) * (c[0] - a[0]))
+
+
+def _segments_intersect(p1, p2, p3, p4) -> bool:
+    """True if open segments p1p2 and p3p4 cross (proper intersection)."""
+    d1 = _cross(p3, p4, p1)
+    d2 = _cross(p3, p4, p2)
+    d3 = _cross(p1, p2, p3)
+    d4 = _cross(p1, p2, p4)
+    return ((d1 > 0) != (d2 > 0)) and ((d3 > 0) != (d4 > 0))
+
+
+def trim_offset_loops(offset_path: np.ndarray) -> np.ndarray:
+    """Remove self-intersection loops from an offset polyline ("sew" it shut).
+
+    When an offset is thrown off the concave side of a bend it can fold back
+    and cross itself.  This excises the looped vertices between each pair of
+    crossing segments, leaving a shorter but crossing-free polyline -- exactly
+    the "the line can just be sewn together to not include this part" behaviour.
+
+    Iterative: find the first pair of non-adjacent segments that cross, drop the
+    vertices strictly between them, and repeat until no crossings remain.
+
+    Parameters
+    ----------
+    offset_path : numpy.ndarray
+        ``(L, 2)`` offset polyline coordinates.
+
+    Returns
+    -------
+    numpy.ndarray
+        ``(L,)`` boolean keep-mask, True for vertices retained in the
+        crossing-free line.  (Apply as ``offset_path[mask]`` for the line, or
+        NaN-out ``~mask`` columns of the sampled curtain.)
+    """
+    pts = np.asarray(offset_path, dtype=np.float64)
+    L = pts.shape[0]
+    if L < 4:
+        return np.ones(L, dtype=bool)
+    idx = list(range(L))
+    changed = True
+    while changed and len(idx) >= 4:
+        changed = False
+        m = len(idx)
+        for a in range(m - 1):
+            for b in range(a + 2, m - 1):
+                if _segments_intersect(
+                    pts[idx[a]], pts[idx[a + 1]],
+                    pts[idx[b]], pts[idx[b + 1]],
+                ):
+                    # Excise the loop: drop vertices a+1 .. b inclusive.
+                    del idx[a + 1:b + 1]
+                    changed = True
+                    break
+            if changed:
+                break
+    mask = np.zeros(L, dtype=bool)
+    mask[idx] = True
+    return mask
+
+
+def transect_front_crossings(
+    axis_path: np.ndarray,
+    normals: np.ndarray,
+    front_mask: np.ndarray,
+    half_width: int,
+) -> np.ndarray:
+    """Count how many times each column's perpendicular transect hits the front.
+
+    Used to keep the auto-picked perpendicular point on a clean stretch: a
+    transect that crosses the front exactly once (the axis itself) shows
+    cross-front dissipation cleanly, while one that crosses several times sits
+    where the front loops back on itself (the squiggly hook) and is hard to
+    interpret.
+
+    Parameters
+    ----------
+    axis_path : numpy.ndarray
+        ``(L, 2)`` main-axis coordinates (cropped frame).
+    normals : numpy.ndarray
+        ``(L, 2)`` unit normals from :func:`path_metrics`.
+    front_mask : numpy.ndarray
+        2-D boolean mask of the selected front (cropped frame).
+    half_width : int
+        Half-width (px) of the transect used at each column.
+
+    Returns
+    -------
+    numpy.ndarray
+        ``(L,)`` int count of distinct front-pixel runs along each transect.
+    """
+    L = axis_path.shape[0]
+    counts = np.zeros(L, dtype=int)
+    fmask = front_mask.astype(np.float64)
+    for c in range(L):
+        perp = perpendicular_path(axis_path, normals, c, half_width)
+        hit = scimg.map_coordinates(
+            fmask, np.stack([perp[:, 0], perp[:, 1]]),
+            order=0, mode="constant", cval=0.0,
+        ) > 0.5
+        # Count rising edges (0 -> 1) = number of distinct crossings.
+        runs = np.diff(np.concatenate([[0], hit.astype(int), [0]]))
+        counts[c] = int((runs == 1).sum())
+    return counts
+
+
 # ---------------------------------------------------------------------------
 # Curtain sampling
 # ---------------------------------------------------------------------------
@@ -632,8 +741,9 @@ def plot_curtain_panel(
 
     # Mixed-layer depth line.
     if mld_curtain is not None:
-        ax.plot(dist_px, mld_curtain, color="white", lw=1.5, ls="--",
-                label="MLD")
+        ax.plot(dist_px, mld_curtain, color="white", lw=1.8, ls="--",
+                label="mixed-layer depth")
+        ax.legend(loc="lower left", fontsize=8, framealpha=0.85)
 
     # Overlap shading: vertical spans on flagged columns.
     if overlap_flags is not None and overlap_flags.any():
@@ -649,23 +759,28 @@ def plot_curtain_panel(
     ax.set_xlabel("distance along path [px]")
     ax.set_ylabel("depth [m]")
     if title:
-        ax.set_title(title, fontsize=10)
+        ax.set_title(title, fontsize=10, pad=24)  # pad leaves room for km axis
 
-    # Secondary km axis on top.
+    # Colorbar in its own axes carved from the right of the panel, so it sits
+    # fully to the RIGHT of the data instead of overlapping it.  Done before
+    # the km twin so the twin inherits the panel's final (shrunk) position and
+    # the two x-axes stay aligned.
+    if add_colorbar:
+        from mpl_toolkits.axes_grid1 import make_axes_locatable
+        divider = make_axes_locatable(ax)
+        cax = divider.append_axes("right", size="2.5%", pad=0.08)
+        cbar = ax.figure.colorbar(mesh, cax=cax)
+        cbar.set_label(color_title)
+
+    # Secondary km axis on top (created last so it tracks ax's final position).
     if dist_km is not None:
         ax_km = ax.twiny()
         ax_km.set_xlim(ax.get_xlim())
-        # Place ~6 ticks at pixel positions, labelled with km.
         xticks = np.linspace(dist_px[0], dist_px[-1], 6)
-        # Interpolate km at those pixel positions.
         km_at = np.interp(xticks, dist_px, dist_km)
         ax_km.set_xticks(xticks)
         ax_km.set_xticklabels([f"{v:.1f}" for v in km_at])
         ax_km.set_xlabel("distance along path [km]")
-
-    if add_colorbar:
-        cbar = ax.figure.colorbar(mesh, ax=ax, shrink=0.85, pad=0.02)
-        cbar.set_label(color_title)
 
 
 # ---------------------------------------------------------------------------
@@ -746,13 +861,19 @@ def figure_offsets(
     color_title: str = "",
     mark_index: int | None = None,
     title: str | None = None,
+    trim: bool = True,
 ):
     """Figure 2 -- along-front curtains with offsets (two columns).
 
     Row 0 of both columns is the main-axis curtain itself.  Rows 1..N show
     offsets 1..N pixels to side A (left column) and side B (right column).
-    Columns whose offset geometry self-overlaps are shaded (see
-    :func:`offset_quality_flags`).
+
+    When ``trim`` is True (default), each offset polyline is "sewn" shut with
+    :func:`trim_offset_loops` -- the self-intersection loops on the concave
+    side of bends are excised and those columns render as neutral-gray gaps,
+    so the curtain only shows the crossing-free part of each offset.  When
+    ``trim`` is False the loops are kept and instead shaded magenta via
+    :func:`offset_quality_flags`.
 
     Parameters
     ----------
@@ -809,12 +930,22 @@ def figure_offsets(
                 row_title = f"{col_label[col]}: main axis (offset 0)"
                 mk = mark_index
             else:
-                flags = offset_quality_flags(pth)
-                n_flag = int(flags.sum())
-                row_title = (f"{col_label[col]}: offset {row} px"
-                             + (f"  [{n_flag} overlap cols shaded]"
-                                if n_flag else ""))
                 mk = None
+                if trim:
+                    keep = trim_offset_loops(pth)
+                    n_drop = int((~keep).sum())
+                    # NaN the looped columns so they render as gray gaps.
+                    color_curtain[:, ~keep] = np.nan
+                    sigma0_curtain[:, ~keep] = np.nan
+                    row_title = (f"{col_label[col]}: offset {row} px"
+                                 + (f"  [{n_drop} looped cols trimmed]"
+                                    if n_drop else ""))
+                else:
+                    flags = offset_quality_flags(pth)
+                    n_flag = int(flags.sum())
+                    row_title = (f"{col_label[col]}: offset {row} px"
+                                 + (f"  [{n_flag} overlap cols shaded]"
+                                    if n_flag else ""))
             plot_curtain_panel(
                 ax, dist_px, Z, color_curtain, sigma0_curtain,
                 dist_km=dist_km, levels=levels, clim=clim, cmap=cmap,

--- a/fronts/viz/curtains.py
+++ b/fronts/viz/curtains.py
@@ -1080,10 +1080,16 @@ def figure_perpendicular(
     # Signed cross-front distance in pixels: -half_width .. +half_width.
     signed_px = np.arange(-int(half_width), int(half_width) + 1, dtype=float)
 
+    # Signed km for the twin axis (when lon/lat provided): re-center the
+    # cumulative along-transect distance so 0 km sits at the front axis.
+    signed_km = None
+    if metrics["dist_km"] is not None:
+        signed_km = metrics["dist_km"] - metrics["dist_km"][int(half_width)]
+
     fig, ax = plt.subplots(figsize=(9, 5))
     plot_curtain_panel(
         ax, signed_px, Z, color_curtain, sigma0_curtain,
-        dist_km=None,  # signed axis; km twin handled below if desired
+        dist_km=signed_km,
         levels=levels, clim=clim, cmap=cmap, color_title=color_title,
         mark_index=int(half_width),  # the axis crossing at 0
         title=title or "Cross-front (perpendicular) curtain",

--- a/fronts/viz/field_styles.py
+++ b/fronts/viz/field_styles.py
@@ -62,6 +62,11 @@ class FieldStyle:
         Linear threshold for ``symlog`` (ignored otherwise).
     clim : tuple of (float, float) or None
         Pinned post-transform color limits.  None -> percentile-based.
+    scale : float
+        Divisor applied to the values in the ``linear`` transform (after any
+        ``clip``), so the displayed numbers are ``value / scale`` -- e.g.
+        ``scale=1e-7`` shows the field in units of 1e-7.  Ignored by the
+        ``log10`` / ``symlog`` transforms.
     """
     transform: str = "linear"
     clip: tuple[float, float] | None = None
@@ -70,6 +75,7 @@ class FieldStyle:
     center: float | None = None
     linthresh: float = 1e-12
     clim: tuple[float, float] | None = None
+    scale: float = 1.0
 
 
 # Keyed by the tile NetCDF variable name (= out_name in the preprocessing
@@ -115,8 +121,8 @@ FIELD_STYLES: dict[str, FieldStyle] = {
         title="log10(strain [s^-1])",
     ),
     "okubo_weiss": FieldStyle(
-        transform="symlog", cmap="RdBu_r",
-        title="symlog(OW [s^-2])", center=0.0, linthresh=1e-11,
+        transform="linear", cmap="RdBu_r",
+        title="OW [s^-2]", center=0.0, 
     ),
     "Ro": FieldStyle(
         transform="linear", clip=(-10.0, 10.0), cmap="RdBu_r",
@@ -131,12 +137,12 @@ FIELD_STYLES: dict[str, FieldStyle] = {
         title="log10(Bu)",
     ),
     "Fs": FieldStyle(
-        transform="symlog", cmap="RdBu_r",
-        title="symlog(F [s^-5])", center=0.0, linthresh=1e-19,
+        transform="linear", scale=1e-7, cmap="RdBu_r",
+        title="Fs [s^-5]", center=0.0,
     ),
     "ertel_pv": FieldStyle(
-        transform="symlog", cmap="RdBu_r",
-        title="symlog(q [m^-1 s^-1])", center=0.0, linthresh=1e-12,
+        transform="linear", scale=1e-7, cmap="RdBu_r",
+        title="q / 1e-7 [s^-3]", center=0.0,
     ),
     "turner_angle": FieldStyle(
         transform="linear", cmap="twilight_shifted",
@@ -227,6 +233,8 @@ def apply_transform(
     if transform == "linear":
         if clip is not None:
             out = np.clip(out, clip[0], clip[1])
+        if style.scale != 1.0:
+            out = out / style.scale
         return out
 
     raise ValueError(

--- a/fronts/viz/field_styles.py
+++ b/fronts/viz/field_styles.py
@@ -142,6 +142,13 @@ FIELD_STYLES: dict[str, FieldStyle] = {
         transform="linear", cmap="twilight_shifted",
         title="Tu [deg]", center=0.0,
     ),
+    "wB": FieldStyle(
+        # Signed vertical buoyancy flux (down/up-gradient); symlog + diverging
+        # map centred on 0, like okubo_weiss / Fs.  linthresh is a starting
+        # point -- retune per the field's magnitude if the centre washes out.
+        transform="symlog", cmap="RdBu_r",
+        title="symlog(wB [m^3 s^-3])", center=0.0, linthresh=1e-4,
+    ),
 }
 
 

--- a/fronts/viz/field_styles.py
+++ b/fronts/viz/field_styles.py
@@ -1,0 +1,264 @@
+"""
+Display styles for coloring 3-D front scenes by a secondary field.
+
+The preprocessing repo's ``dbof/tiles/field_registry.py`` defines *what* can
+be computed into a tile NetCDF (raw physical values, no display policy).
+This module is its display-side counterpart: for each tile variable name
+(``out_name`` in the preprocessing registry, e.g. ``"Ri"``, ``"vorticity"``)
+it declares *how* the field should be transformed and colored when used as
+the color scalar in ``fronts_viz_3d``.
+
+The two registries are deliberately decoupled -- they are matched only by
+the variable name stored in the tile NetCDF, which is self-describing
+(``units`` / ``long_name`` attrs).  Unknown variables fall back to a linear
+transform with percentile color limits (see :func:`get_style`).
+
+Transforms
+----------
+``log10``
+    ``log10(clip(x, *clip))`` with non-positive values -> NaN.  For
+    positive-definite fields spanning decades (Ri, N2, shear, |grad b|^2).
+``symlog``
+    Signed pseudo-log: ``sign(x) * log10(1 + |x| / linthresh)``.  For signed
+    fields spanning decades (Okubo-Weiss, frontogenesis, Ertel PV).
+``linear``
+    Optionally clipped passthrough.  For bounded or narrow-range fields
+    (vorticity, divergence, Turner angle).
+
+A ``center`` of 0.0 marks diverging fields: the default color limits are
+made symmetric about 0 so the colormap midpoint sits at zero.
+"""
+
+# stdlib
+from __future__ import annotations
+from dataclasses import dataclass
+
+# numerical
+import numpy as np
+
+
+# Neutral gray used for NaN cells (land, clipped, undefined) on colored
+# surfaces -- keeps the geometry hole-free while flagging missing data.
+NAN_COLOR = "#9e9e9e"
+
+
+@dataclass(frozen=True)
+class FieldStyle:
+    """Display policy for one tile variable used as a color scalar.
+
+    Attributes
+    ----------
+    transform : str
+        ``'log10'``, ``'symlog'``, or ``'linear'``.
+    clip : tuple of (float, float) or None
+        Clip range applied in *raw* units before the transform.
+    cmap : str
+        Default colormap (PyVista/matplotlib name).
+    title : str
+        Scalar-bar title (post-transform units).
+    center : float or None
+        If set (typically 0.0), default clim is symmetric about it.
+    linthresh : float
+        Linear threshold for ``symlog`` (ignored otherwise).
+    clim : tuple of (float, float) or None
+        Pinned post-transform color limits.  None -> percentile-based.
+    """
+    transform: str = "linear"
+    clip: tuple[float, float] | None = None
+    cmap: str = "viridis"
+    title: str = ""
+    center: float | None = None
+    linthresh: float = 1e-12
+    clim: tuple[float, float] | None = None
+
+
+# Keyed by the tile NetCDF variable name (= out_name in the preprocessing
+# field registry).  Add a row when you add a property over there.
+FIELD_STYLES: dict[str, FieldStyle] = {
+    "sigma0": FieldStyle(
+        transform="linear", cmap="dense",
+        title="sigma0 [kg/m^3]",
+    ),
+    "Theta": FieldStyle(
+        transform="linear", cmap="thermal",
+        title="Theta [degC]",
+    ),
+    "Salt": FieldStyle(
+        transform="linear", cmap="haline",
+        title="Salt [psu]",
+    ),
+    "Ri": FieldStyle(
+        transform="log10", clip=(1e-2, 1e4), cmap="RdYlBu",
+        title="log10(Ri)",
+        # Ri = 0.25 (log10 ~ -0.6) is the shear-instability threshold;
+        # this clim keeps the unstable range in the warm half of the bar.
+        clim=(-1.0, 2.0),
+    ),
+    "N2": FieldStyle(
+        transform="log10", clip=(1e-9, 1e-3), cmap="viridis",
+        title="log10(N^2 [s^-2])",
+    ),
+    "vertical_shear": FieldStyle(
+        transform="log10", clip=(1e-6, 1e-1), cmap="viridis",
+        title="log10(|S| [s^-1])",
+    ),
+    "vorticity": FieldStyle(
+        transform="linear", cmap="RdBu_r",
+        title="zeta [1/s]", center=0.0,
+    ),
+    "divergence": FieldStyle(
+        transform="linear", cmap="RdBu_r",
+        title="div [1/s]", center=0.0,
+    ),
+    "strain": FieldStyle(
+        transform="log10", clip=(1e-8, 1e-3), cmap="viridis",
+        title="log10(strain [s^-1])",
+    ),
+    "okubo_weiss": FieldStyle(
+        transform="symlog", cmap="RdBu_r",
+        title="symlog(OW [s^-2])", center=0.0, linthresh=1e-11,
+    ),
+    "Ro": FieldStyle(
+        transform="linear", clip=(-10.0, 10.0), cmap="RdBu_r",
+        title="Ro", center=0.0,
+    ),
+    "Fr": FieldStyle(
+        transform="log10", clip=(1e-3, 1e1), cmap="viridis",
+        title="log10(Fr)",
+    ),
+    "Bu": FieldStyle(
+        transform="log10", clip=(1e-3, 1e3), cmap="viridis",
+        title="log10(Bu)",
+    ),
+    "Fs": FieldStyle(
+        transform="symlog", cmap="RdBu_r",
+        title="symlog(F [s^-5])", center=0.0, linthresh=1e-19,
+    ),
+    "ertel_pv": FieldStyle(
+        transform="symlog", cmap="RdBu_r",
+        title="symlog(q [m^-1 s^-1])", center=0.0, linthresh=1e-12,
+    ),
+    "turner_angle": FieldStyle(
+        transform="linear", cmap="twilight_shifted",
+        title="Tu [deg]", center=0.0,
+    ),
+}
+
+
+def get_style(var_name: str) -> FieldStyle:
+    """Look up the style for a tile variable, with a safe linear fallback.
+
+    Parameters
+    ----------
+    var_name : str
+        Tile NetCDF variable name.
+
+    Returns
+    -------
+    FieldStyle
+        The registered style, or a default linear style (titled with the
+        variable name) when the field is unknown.
+    """
+    style = FIELD_STYLES.get(var_name)
+    if style is None:
+        import logging
+        logging.getLogger(__name__).warning(
+            "No FIELD_STYLES entry for %r -- falling back to a linear "
+            "transform with percentile color limits.  Add an entry to "
+            "fronts/viz/field_styles.py to control its display.", var_name,
+        )
+        return FieldStyle(title=var_name)
+    return style
+
+
+def apply_transform(
+    values: np.ndarray,
+    style: FieldStyle,
+    *,
+    clip_override: tuple[float, float] | None = None,
+    transform_override: str | None = None,
+) -> np.ndarray:
+    """Transform raw field values into display values per a style.
+
+    Non-finite inputs stay NaN.  For ``log10``, values <= 0 become NaN
+    (e.g. negative Ri from unstable stratification) and the remainder are
+    clipped into ``clip`` before the log.  For ``symlog`` and ``linear``,
+    clipping (when configured) is a plain ``np.clip``.
+
+    Parameters
+    ----------
+    values : numpy.ndarray
+        Raw field values (any shape).
+    style : FieldStyle
+        Display policy (see :data:`FIELD_STYLES`).
+    clip_override, transform_override : optional
+        CLI-level overrides for the style's ``clip`` / ``transform``.
+
+    Returns
+    -------
+    numpy.ndarray
+        float64 array of display values, NaN where undefined.
+    """
+    transform = transform_override or style.transform
+    clip = clip_override if clip_override is not None else style.clip
+
+    out = np.asarray(values, dtype=np.float64).copy()
+
+    if transform == "log10":
+        out[~np.isfinite(out)] = np.nan
+        out[out <= 0] = np.nan
+        if clip is not None:
+            out = np.clip(out, clip[0], clip[1])
+        return np.log10(out)
+
+    if transform == "symlog":
+        if clip is not None:
+            out = np.clip(out, clip[0], clip[1])
+        lt = float(style.linthresh)
+        return np.sign(out) * np.log10(1.0 + np.abs(out) / lt)
+
+    if transform == "linear":
+        if clip is not None:
+            out = np.clip(out, clip[0], clip[1])
+        return out
+
+    raise ValueError(
+        f"Unknown transform {transform!r}; expected 'log10', 'symlog', "
+        "or 'linear'."
+    )
+
+
+def default_clim(
+    display_values: np.ndarray,
+    style: FieldStyle,
+    *,
+    percentile_low: float = 2.0,
+    percentile_high: float = 98.0,
+) -> tuple[float, float]:
+    """Default post-transform color limits for a field.
+
+    Order of precedence: the style's pinned ``clim``; symmetric limits about
+    ``style.center`` (when set) using the larger percentile excursion; plain
+    2/98 percentiles otherwise.
+
+    Parameters
+    ----------
+    display_values : numpy.ndarray
+        Transformed (display-space) values; NaNs ignored.
+    style : FieldStyle
+        Display policy.
+    percentile_low, percentile_high : float, optional
+        Percentile bounds (default 2/98).
+
+    Returns
+    -------
+    tuple of (float, float)
+    """
+    if style.clim is not None:
+        return tuple(style.clim)
+    lo = float(np.nanpercentile(display_values, percentile_low))
+    hi = float(np.nanpercentile(display_values, percentile_high))
+    if style.center is not None:
+        span = max(abs(lo - style.center), abs(hi - style.center))
+        return (style.center - span, style.center + span)
+    return (lo, hi)

--- a/fronts/viz/field_styles.py
+++ b/fronts/viz/field_styles.py
@@ -247,14 +247,18 @@ def default_clim(
     display_values: np.ndarray,
     style: FieldStyle,
     *,
+    clip_override: tuple[float, float] | None = None,
+    transform_override: str | None = None,
     percentile_low: float = 2.0,
     percentile_high: float = 98.0,
 ) -> tuple[float, float]:
     """Default post-transform color limits for a field.
 
-    Order of precedence: the style's pinned ``clim``; symmetric limits about
-    ``style.center`` (when set) using the larger percentile excursion; plain
-    2/98 percentiles otherwise.
+    Order of precedence: the style's pinned ``clim`` (only when neither
+    override is given -- a pinned clim is calibrated to the style's own
+    display space, so a CLI transform/clip override invalidates it);
+    symmetric limits about ``style.center`` (when set) using the larger
+    percentile excursion; plain 2/98 percentiles otherwise.
 
     Parameters
     ----------
@@ -262,6 +266,9 @@ def default_clim(
         Transformed (display-space) values; NaNs ignored.
     style : FieldStyle
         Display policy.
+    clip_override, transform_override : optional
+        CLI-level overrides for the style's ``clip`` / ``transform``.
+        Pass the same values given to :func:`apply_transform`.
     percentile_low, percentile_high : float, optional
         Percentile bounds (default 2/98).
 
@@ -269,7 +276,12 @@ def default_clim(
     -------
     tuple of (float, float)
     """
-    if style.clim is not None:
+    style_clim_ok = (
+        style.clim is not None
+        and clip_override is None
+        and transform_override is None
+    )
+    if style_clim_ok:
         return tuple(style.clim)
     lo = float(np.nanpercentile(display_values, percentile_low))
     hi = float(np.nanpercentile(display_values, percentile_high))

--- a/fronts/viz/field_styles.py
+++ b/fronts/viz/field_styles.py
@@ -153,7 +153,7 @@ FIELD_STYLES: dict[str, FieldStyle] = {
         # map centred on 0, like okubo_weiss / Fs.  linthresh is a starting
         # point -- retune per the field's magnitude if the centre washes out.
         transform="symlog", cmap="RdBu_r",
-        title="symlog(wB [m^3 s^-3])", center=0.0, linthresh=1e-4,
+        title="symlog(wB [m^2 s^-3])", center=0.0, linthresh=1e-4,
     ),
 }
 

--- a/fronts/viz/field_styles.py
+++ b/fronts/viz/field_styles.py
@@ -122,7 +122,7 @@ FIELD_STYLES: dict[str, FieldStyle] = {
     ),
     "okubo_weiss": FieldStyle(
         transform="linear", cmap="RdBu_r",
-        title="OW [s^-2]", center=0.0, 
+        title="OW [s^-2]", center=0.0,
     ),
     "Ro": FieldStyle(
         transform="linear", clip=(-10.0, 10.0), cmap="RdBu_r",

--- a/fronts/viz/fronts_3d.py
+++ b/fronts/viz/fronts_3d.py
@@ -144,6 +144,7 @@ def build_pyvista_grid(
     zscale: float = 50.0,
     *,
     mask_2d: np.ndarray | None = None,
+    extra_fields: dict[str, np.ndarray] | None = None,
 ) -> pv.RectilinearGrid:
     """Wrap a cropped+clipped sigma0 array as a PyVista ``RectilinearGrid``.
 
@@ -171,12 +172,21 @@ def build_pyvista_grid(
         inside the mask.  Use this together with
         :func:`dilate_front_mask` to render iso-surfaces only in a
         dilated region around the selected front.
+    extra_fields : dict of str -> numpy.ndarray, optional
+        Additional point-data scalars to stamp alongside ``sigma0``, each
+        of the same ``(K_clip, J', I')`` shape (e.g. a transformed
+        Richardson-number volume named ``"log10_Ri"``).  VTK's ``contour``
+        filter interpolates *all* point arrays onto extracted iso-surfaces,
+        so any field stamped here can be used to color sigma0 iso-surfaces
+        via ``render_3d(color_scalar=...)``.  The ``mask_2d`` NaN-out (when
+        given) is applied to these fields too.
 
     Returns
     -------
     pyvista.RectilinearGrid
-        Grid with ``grid["sigma0"]`` stamped using Fortran order (the
-        documented silent-bug trap in PyVista's RectilinearGrid).
+        Grid with ``grid["sigma0"]`` (and each ``extra_fields`` entry)
+        stamped using Fortran order (the documented silent-bug trap in
+        PyVista's RectilinearGrid).
     """
     K_clip, Jp, Ip = sigma0_clipped.shape
 
@@ -191,21 +201,34 @@ def build_pyvista_grid(
 
     # VTK expects Fortran-ordered scalar arrays for image/rectilinear grids;
     # the patterns reference flags C-order as the most common silent bug.
-    # sigma0_clipped has axes (k, j, i); we want the iteration order to
-    # match (x, y, z) = (i, j, k), so transpose first then ravel('F').
-    field = sigma0_clipped.astype(np.float32, copy=True)
-    if mask_2d is not None:
-        if mask_2d.shape != (Jp, Ip):
+    # The arrays have axes (k, j, i); we want the iteration order to match
+    # (x, y, z) = (i, j, k), so transpose first then ravel('F').
+    def _stamp(name: str, arr: np.ndarray) -> None:
+        if arr.shape != (K_clip, Jp, Ip):
             raise ValueError(
-                f"mask_2d shape {mask_2d.shape} does not match the (J, I) "
-                f"axes of sigma0_clipped ({Jp}, {Ip})."
+                f"field {name!r} shape {arr.shape} does not match "
+                f"sigma0_clipped {(K_clip, Jp, Ip)}."
             )
-        # Broadcast the 2-D mask along k so the same (j,i) pixels are
-        # active at every depth; contour() will then trace surfaces
-        # restricted to the columns where the mask is True.
-        field[:, ~mask_2d] = np.nan
-    field = np.transpose(field, (2, 1, 0))
-    grid["sigma0"] = field.ravel(order="F")
+        field = arr.astype(np.float32, copy=True)
+        if mask_2d is not None:
+            if mask_2d.shape != (Jp, Ip):
+                raise ValueError(
+                    f"mask_2d shape {mask_2d.shape} does not match the "
+                    f"(J, I) axes of the volume ({Jp}, {Ip})."
+                )
+            # Broadcast the 2-D mask along k so the same (j,i) pixels are
+            # active at every depth; contour() will then trace surfaces
+            # restricted to the columns where the mask is True.
+            field[:, ~mask_2d] = np.nan
+        grid[name] = np.transpose(field, (2, 1, 0)).ravel(order="F")
+
+    _stamp("sigma0", sigma0_clipped)
+    if extra_fields:
+        for name, arr in extra_fields.items():
+            _stamp(name, arr)
+    # contour() defaults to the active scalars; keep that sigma0 so the
+    # geometry is always density-driven regardless of stamping order.
+    grid.set_active_scalars("sigma0")
     return grid
 
 
@@ -784,11 +807,23 @@ def render_3d(
     front_iso_color: str = "orange",
     front_iso_opacity: float = 0.95,
     draw_curtain: bool = False,
+    color_scalar: str = "sigma0",
+    color_title: str | None = None,
+    nan_color: str = "#9e9e9e",
+    nan_opacity: float = 1.0,
+    front_iso_use_color_scalar: bool = True,
     font_size: int = 56,
     title_font_size: int = 60,
     label_font_size: int = 44,
 ) -> pv.Plotter:
     """Assemble the 3-D scene: isopycnals / volume + curtain + top marker + axes.
+
+    Geometry is always sigma0-driven (contours extract density surfaces);
+    *coloring* follows ``color_scalar``, which may be any point-data array
+    stamped on the grid via ``build_pyvista_grid(extra_fields=...)`` --
+    VTK interpolates every point array onto the extracted iso-surfaces.
+    With the default ``color_scalar='sigma0'`` the scene is identical to
+    the classic single-field behaviour.
 
     Parameters
     ----------
@@ -801,11 +836,13 @@ def render_3d(
     mode : {'isopycnals', 'volume'}, optional
         ``'isopycnals'`` (default) draws ``grid.contour(levels)`` with a
         semi-transparent fill; ``'volume'`` calls ``add_volume`` with the
-        chosen opacity transfer function.
+        chosen opacity transfer function.  Volume mode always renders
+        sigma0 (a secondary-field volume is not supported).
     clim : tuple of (float, float), optional
-        Colour-scale limits for sigma0; default 2/98 percentile of the
-        grid scalars.  For better mixed-layer contrast pass
-        :func:`mixed_layer_clim`'s output.
+        Colour-scale limits for the *color scalar*; default 2/98
+        percentile of that scalar on the grid.  For better mixed-layer
+        contrast pass :func:`mixed_layer_clim`'s output (computed on the
+        same scalar).
     cmap_volume, cmap_curtain : str, optional
         Colormaps for the background and curtain respectively.
     opacity : str, optional
@@ -822,6 +859,27 @@ def render_3d(
         colour so the front's lateral position is visible from above.
     top_marker_color : str, optional
         Colour of the top-layer marker (default ``'red'``).
+    front_iso : pyvista.PolyData, optional
+        Single sigma0 iso-surface from :func:`build_front_isosurface`.
+    front_iso_color : str, optional
+        Solid colour for the front iso-surface when it is NOT being
+        coloured by the color scalar (default ``'orange'``).
+    color_scalar : str, optional
+        Name of the point-data array used for coloring (default
+        ``'sigma0'``).  Must be stamped on the grid.
+    color_title : str, optional
+        Scalar-bar title.  Defaults to ``"sigma0 [kg/m^3]"`` for sigma0,
+        else the scalar name.
+    nan_color : str, optional
+        Colour for NaN values of the color scalar on extracted surfaces
+        (default neutral gray ``'#9e9e9e'``) -- keeps surfaces hole-free
+        over land / clipped / undefined cells.
+    nan_opacity : float, optional
+        Opacity of NaN-coloured cells (default 1.0; set 0 to hide them).
+    front_iso_use_color_scalar : bool, optional
+        When True (default) and ``color_scalar != 'sigma0'``, the front
+        iso-surface is coloured by the color scalar too (e.g. Ri along the
+        tilted front sheet) instead of the solid ``front_iso_color``.
     font_size, title_font_size, label_font_size : int, optional
         Font sizes for axes / scalar-bar titles / scalar-bar tick labels.
 
@@ -838,11 +896,23 @@ def render_3d(
     theme = scientific_theme(font_size=font_size, label_size=label_font_size)
     pl = new_plotter(off_screen=not show, theme=theme)
 
-    # Default contrast: 2/98 percentile of the grid scalars.  Callers
+    # Resolve the coloring scalar + title.  Geometry stays sigma0-driven;
+    # only the colors follow color_scalar.
+    if color_scalar != "sigma0" and color_scalar not in grid.array_names:
+        raise ValueError(
+            f"color_scalar {color_scalar!r} is not stamped on the grid "
+            f"(available: {list(grid.array_names)}).  Pass it via "
+            "build_pyvista_grid(extra_fields=...)."
+        )
+    if color_title is None:
+        color_title = ("sigma0 [kg/m^3]" if color_scalar == "sigma0"
+                       else color_scalar)
+
+    # Default contrast: 2/98 percentile of the coloring scalar.  Callers
     # that want mixed-layer-focused contrast should pass `clim=` from
-    # :func:`mixed_layer_clim` instead.
+    # :func:`mixed_layer_clim` (computed on the same scalar) instead.
     if clim is None:
-        scalars = np.asarray(grid["sigma0"])
+        scalars = np.asarray(grid[color_scalar])
         clim = (
             float(np.nanpercentile(scalars, 2)),
             float(np.nanpercentile(scalars, 98)),
@@ -875,23 +945,31 @@ def render_3d(
         )
 
     if mode == "isopycnals":
+        # Contour on sigma0 (geometry); VTK interpolates every other point
+        # array onto the surfaces, so coloring by color_scalar is free.
         iso = grid.contour(isosurfaces=list(levels), scalars="sigma0")
         if iso.n_points > 0:
             pl.add_mesh(
                 iso,
-                scalars="sigma0",
+                scalars=color_scalar,
                 cmap=cmap_volume,
                 clim=clim,
                 opacity=0.6,
                 smooth_shading=True,
+                nan_color=nan_color,
+                nan_opacity=nan_opacity,
                 scalar_bar_args=_sb_args(
-                    "sigma0 [kg/m^3]", position_y=0.30,
+                    color_title, position_y=0.30,
                 ),
             )
     elif mode == "volume":
+        # Volume mode renders the sigma0 field itself; coloring a sigma0
+        # volume by a second scalar is ill-defined, so color_scalar is
+        # ignored here (documented in the docstring).
         pl.add_volume(
             grid, scalars="sigma0",
-            cmap=cmap_volume, clim=clim, opacity=opacity,
+            cmap=cmap_volume, clim=clim if color_scalar == "sigma0" else None,
+            opacity=opacity,
             scalar_bar_args=_sb_args(
                 "sigma0 [kg/m^3]", position_y=0.55,
             ),
@@ -934,18 +1012,38 @@ def render_3d(
                 )
 
     # Front iso-surface -- a single sigma0 iso-surface that naturally
-    # tilts with depth across the front.  Drawn opaque in a distinct
-    # colour so the tilt geometry (dense waters on one side, less dense
-    # on the other) reads at a glance against the semi-transparent
-    # context iso-surfaces.
+    # tilts with depth across the front.  In single-field mode it is drawn
+    # opaque in a distinct colour so the tilt geometry (dense waters on one
+    # side, less dense on the other) reads at a glance.  In dual-field mode
+    # (color_scalar != 'sigma0') it is coloured by the color scalar instead
+    # -- e.g. Ri along the tilted front sheet shows directly where the
+    # front is shear-unstable.
     if front_iso is not None and front_iso.n_points > 0:
-        pl.add_mesh(
-            front_iso,
-            color=front_iso_color,
-            opacity=front_iso_opacity,
-            smooth_shading=True,
-            show_scalar_bar=False,
+        color_front_by_scalar = (
+            front_iso_use_color_scalar
+            and color_scalar != "sigma0"
+            and color_scalar in front_iso.array_names
         )
+        if color_front_by_scalar:
+            pl.add_mesh(
+                front_iso,
+                scalars=color_scalar,
+                cmap=cmap_volume,
+                clim=clim,
+                opacity=front_iso_opacity,
+                smooth_shading=True,
+                nan_color=nan_color,
+                nan_opacity=nan_opacity,
+                show_scalar_bar=False,
+            )
+        else:
+            pl.add_mesh(
+                front_iso,
+                color=front_iso_color,
+                opacity=front_iso_opacity,
+                smooth_shading=True,
+                show_scalar_bar=False,
+            )
 
     # Top-layer marker (optional).  Drawn in a single bright fixed colour
     # so the front's lateral position is identifiable in plan view, but

--- a/prompts/pull_requests.md
+++ b/prompts/pull_requests.md
@@ -1,0 +1,44 @@
+# Pull Requests
+
+This file will hold prompts to perform reviews of pull requests.
+
+All of these will be at:
+https://github.com/Sea-Meets-the-Stars/fronts/pull/##
+
+## PR 22
+
+1. Review PR 22 and post to GitHub.  Be sure to include comments on specific lines.  If you have any questions, put them under the Clarifications section. Log your work.
+
+### Clarifications
+
+1. **Merge dependency.** The PR body says this requires the `tile_fields` branch in the preprocessing repo, which is not yet merged to `main`. Is merging PR 22 blocked on that branch landing first, or is it fine to merge the fronts side ahead of it (the new code degrades to a clear `ImportError`/`SystemExit` without it)?
+2. **`--clim` default semantics.** When `--field-transform`/`--field-clip` are overridden, should the pinned style `clim` be honored or dropped in favor of percentiles? `fronts_viz_3d` drops it; `fronts_viz_curtain` keeps it (see the inline comment on `fronts_viz_curtain.py:544`). Which is the intended behavior — I'll align both to match.
+3. **Tests.** Are unit tests for `field_styles.py` and the figure assemblers in scope for this PR, or deferred to a follow-up?
+
+## Logging
+
+The "Logs" section will record Claude's work.  Please use the following format:
+
+### <Date> (Short summary of the work)
+
+<Detailed description of the work and what you learned>
+
+...
+
+## Logs
+
+### 2026-06-30 (Reviewed PR 22 — dual-field 3-D coloring + 2-D curtains)
+
+Reviewed [PR 22](https://github.com/Sea-Meets-the-Stars/fronts/pull/22) ("Plot any field in 3D or in 2D along/across front curtains", +3111/-75, 12 files) and posted a `COMMENTED` review with 6 inline comments ([review](https://github.com/Sea-Meets-the-Stars/fronts/pull/22#pullrequestreview-4600886638)).
+
+**What the PR does:** generalizes the isopycnal 3-D viz so any field can color the σ0 iso-surfaces (geometry stays density-driven; the color field rides along via VTK's `contour` filter interpolating every point array onto the extracted surfaces — no resampling code). Adds `fronts/viz/field_styles.py` (per-variable transform/clip/cmap/title/center registry), `fronts/viz/curtains.py` + `fronts/scripts/fronts_viz_curtain.py` (2-D vertical "curtain" cross-sections: main-axis, along-front offsets, perpendicular transect), and refactors `dev/mld/density_utils.py` (`load_tile` generalized from `load_density_tile`; `check_tiles_consistent`; robust `tile_mapping` import via installed `dbof` → `LLC4320_PREPROC_SRC` env var → clear `ImportError`).
+
+**Findings posted (all non-blocking):**
+- `fronts_viz_curtain.py:544` — likely real bug: `default_clim` returns the pinned style `clim` even when `--field-transform`/`--field-clip` are overridden, unlike `fronts_viz_3d.py` which guards with `style_clim_ok`. A `symlog` override on Ri would get a `log10`-space colorbar. (strongest finding)
+- `density_utils.py:222` — `check_tiles_consistent` raises `SystemExit` from a shared util (sibling `load_tile` uses `KeyError`); suggested `ValueError` + CLI translation.
+- `curtains.py:480` — `trim_offset_loops` is worst-case ~O(L³) (restarts the O(L²) scan after each excision); fine for typical lengths, suggested an iteration note/cap.
+- `curtains.py:1053` — `figure_perpendicular` computes `path_metrics(perp_path, …)` whose result is unused (dead work + misleading `XC/YC` args); tie to the documented km-twin-axis follow-up.
+- `field_styles.py:125` — trailing whitespace on the `okubo_weiss` entry.
+- `test_curtains.py:6` — no tests for `field_styles.py` (`apply_transform`/`default_clim`) or the figure assemblers.
+
+**What I learned / verified:** confirmed top-level `dbof` resolves to the installed preprocessing repo (no collision with `fronts.dbof`); `mixed_layer_clim` is NaN-safe (`nanpercentile`), so feeding it the NaN-laden transformed field is OK. The dual-field path is fully backward compatible — without `--field-tile` the 3-D scene is unchanged. 3 questions raised under Clarifications (merge dependency on the unmerged `tile_fields` preprocessing branch; intended `--clim`-vs-override semantics; whether the missing tests are in scope).


### PR DESCRIPTION
Builds off of the isopycnal 3D plots and adds functionality to plot any field in 3D along the isopycnals (i.e. fields = colors; geometry/surfaces = density). Also adds functionality for plotting in 2D in along/across-front curtains.

This code requires outputs from the tile_fields branch in the preprocessing repo, which has not yet been merged to main.